### PR TITLE
Fix save-credentials form and drop all-caps widget headings

### DIFF
--- a/assets/jot-widget.css
+++ b/assets/jot-widget.css
@@ -27,10 +27,9 @@
 
 .jot-widget__section h4 {
 	margin: 0 0 8px;
-	font-size: 13px;
-	text-transform: uppercase;
-	letter-spacing: 0.04em;
-	color: #50575e;
+	font-size: 14px;
+	font-weight: 600;
+	color: #1d2327;
 }
 
 .jot-widget__empty {

--- a/includes/admin/class-jot-connections-page.php
+++ b/includes/admin/class-jot-connections-page.php
@@ -21,6 +21,18 @@ class Jot_Connections_Page {
 	public const MENU_SLUG       = 'jot-connections';
 	public const APPS_OPTION_KEY = 'jot_oauth_apps';
 
+	/**
+	 * Register admin-post handlers. Must be called on a hook that fires for
+	 * admin-post.php requests (e.g. `init` or `admin_init`), not `admin_menu` —
+	 * admin_menu does NOT fire on admin-post.php, and if form submissions
+	 * target admin-post.php the handler callback must already be attached.
+	 */
+	public static function boot(): void {
+		$instance = new self();
+		add_action( 'admin_post_jot_save_oauth_apps', array( $instance, 'handle_save_apps' ) );
+		add_action( 'admin_post_jot_disconnect_service', array( $instance, 'handle_disconnect' ) );
+	}
+
 	public function register(): void {
 		add_menu_page(
 			__( 'Jot', 'jot' ),
@@ -40,9 +52,6 @@ class Jot_Connections_Page {
 			self::MENU_SLUG,
 			array( $this, 'render' )
 		);
-
-		add_action( 'admin_post_jot_save_oauth_apps', array( $this, 'handle_save_apps' ) );
-		add_action( 'admin_post_jot_disconnect_service', array( $this, 'handle_disconnect' ) );
 	}
 
 	public function handle_save_apps(): void {

--- a/jot.php
+++ b/jot.php
@@ -99,6 +99,9 @@ function jot_boot_subsystems(): void {
 	if ( class_exists( 'Jot_Rest_Controller' ) ) {
 		Jot_Rest_Controller::boot();
 	}
+	if ( class_exists( 'Jot_Connections_Page' ) ) {
+		Jot_Connections_Page::boot();
+	}
 }
 
 add_action( 'wp_dashboard_setup', 'jot_register_dashboard_widget' );


### PR DESCRIPTION
## Summary

Two Phase 1 testing bugs:

1. **Save credentials was broken.** \`admin_post_jot_save_oauth_apps\` was registered inside \`Jot_Connections_Page::register()\`, which only fires on \`admin_menu\`. Form POSTs to \`admin-post.php\` never fire \`admin_menu\`, so the handler was never attached → blank page + lost input. Moved registration to a new static \`boot()\` called from \`jot_boot_subsystems()\` on \`plugins_loaded\`. Same fix covers the Disconnect handler.
2. **Widget section headings were all-caps** with \`letter-spacing: 0.04em\`. That's not consistent with WordPress admin typography. Reverted to normal case, weight 600.

## Test plan

- [ ] Enter GitHub Client ID + Secret in Jot → Connections, hit **Save credentials** → redirect back with "Settings saved" style notice, creds persist (Client Secret shows \`(saved — leave blank to keep)\` placeholder on return).
- [ ] Clicking **Disconnect** on a connected service now redirects back with a notice instead of a blank page.
- [ ] Dashboard widget: "Suggestions" and "Your drafts from Jot" render in normal case, not uppercase.

🤖 Generated with [Craft Agent](https://craft.do)