### PR TITLE
Add Spotify integration

### DIFF
--- a/includes/services/class-jot-service-spotify.php
+++ b/includes/services/class-jot-service-spotify.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Spotify service adapter.
+ *
+ * OAuth2 Authorization Code flow. Access tokens last 1h; refresh tokens are
+ * long-lived. Scope `user-read-recently-played` is the minimum we need for
+ * the last ~50 listening events.
+ *
+ * Docs:
+ *   https://developer.spotify.com/documentation/web-api/tutorials/code-flow
+ *   https://developer.spotify.com/documentation/web-api/reference/get-recently-played
+ *
+ * @package Jot
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+class Jot_Service_Spotify extends Jot_Service_OAuth2 {
+
+	public function __construct() {
+		$this->authorize_url    = 'https://accounts.spotify.com/authorize';
+		$this->access_token_url = 'https://accounts.spotify.com/api/token';
+		$this->scope            = 'user-read-recently-played user-read-email';
+		$this->auth_header_type = 'Bearer';
+	}
+
+	public function id(): string {
+		return 'spotify';
+	}
+
+	public function label(): string {
+		return __( 'Spotify', 'jot' );
+	}
+
+	protected function fetch_connection_meta( string $access_token ): array {
+		$response = wp_remote_get(
+			'https://api.spotify.com/v1/me',
+			array(
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $access_token,
+					'Accept'        => 'application/json',
+					'User-Agent'    => 'Jot/' . JOT_VERSION . '; ' . home_url(),
+				),
+				'timeout' => 10,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return array();
+		}
+
+		$body = json_decode( (string) wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $body ) ) {
+			return array();
+		}
+
+		$display = (string) ( $body['display_name'] ?? '' );
+		$handle  = (string) ( $body['id'] ?? '' );
+		return array(
+			'user_id'  => $handle,
+			'username' => $display !== '' ? $display : $handle,
+			'name'     => $display,
+		);
+	}
+
+	public function fetch_recent( int $since, int $user_id ): array {
+		// Spotify's recently-played "after" is a Unix timestamp in *milliseconds*.
+		$url = add_query_arg(
+			array(
+				'limit' => 50,
+				'after' => $since * 1000,
+			),
+			'https://api.spotify.com/v1/me/player/recently-played'
+		);
+
+		$response = $this->authed_get( $url, $user_id );
+		if ( is_wp_error( $response ) || ! is_array( $response ) || empty( $response['items'] ) || ! is_array( $response['items'] ) ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $response['items'] as $item ) {
+			if ( ! is_array( $item ) || empty( $item['played_at'] ) || empty( $item['track'] ) || ! is_array( $item['track'] ) ) {
+				continue;
+			}
+			$track   = $item['track'];
+			$artists = array();
+			foreach ( (array) ( $track['artists'] ?? array() ) as $artist ) {
+				if ( is_array( $artist ) && ! empty( $artist['name'] ) ) {
+					$artists[] = (string) $artist['name'];
+				}
+			}
+			$played_at = strtotime( (string) $item['played_at'] );
+			if ( $played_at === false ) {
+				continue;
+			}
+			$out[] = array(
+				'track'       => (string) ( $track['name'] ?? '' ),
+				'artists'     => $artists,
+				'album'       => (string) ( $track['album']['name'] ?? '' ),
+				'duration_ms' => (int) ( $track['duration_ms'] ?? 0 ),
+				'at'          => $played_at,
+			);
+		}
+		return $out;
+	}
+}

--- a/includes/signals/class-jot-signals-spotify.php
+++ b/includes/signals/class-jot-signals-spotify.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Spotify signal aggregator.
+ *
+ * Boils a window of listening history into a one-liner like
+ * "23 tracks across 14 artists; most-played: Big Thief (4), Waxahatchee (3)."
+ *
+ * @package Jot
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+class Jot_Signals_Spotify {
+
+	/**
+	 * @param array<int, array<string, mixed>> $plays
+	 */
+	public static function aggregate( array $plays ): string {
+		if ( empty( $plays ) ) {
+			return '';
+		}
+
+		$track_count = 0;
+		$by_artist   = array();
+		$days        = array();
+
+		foreach ( $plays as $p ) {
+			if ( ! is_array( $p ) ) {
+				continue;
+			}
+			$track_count++;
+			$artists = (array) ( $p['artists'] ?? array() );
+			foreach ( $artists as $artist ) {
+				$artist = (string) $artist;
+				if ( $artist === '' ) {
+					continue;
+				}
+				$by_artist[ $artist ] = ( $by_artist[ $artist ] ?? 0 ) + 1;
+			}
+			$at = (int) ( $p['at'] ?? 0 );
+			if ( $at > 0 ) {
+				$days[ gmdate( 'Y-m-d', $at ) ] = true;
+			}
+		}
+
+		if ( $track_count === 0 ) {
+			return '';
+		}
+
+		arsort( $by_artist );
+		$artist_count = count( $by_artist );
+		$top          = array_slice( $by_artist, 0, 3, true );
+
+		$top_parts = array();
+		foreach ( $top as $name => $count ) {
+			$top_parts[] = sprintf( '%s (%d)', $name, $count );
+		}
+
+		$parts = array();
+		$parts[] = sprintf(
+			/* translators: 1: track count, 2: artist count */
+			_n( '%1$d track across %2$d artist', '%1$d tracks across %2$d artists', $track_count, 'jot' ),
+			$track_count,
+			$artist_count
+		);
+
+		if ( ! empty( $top_parts ) ) {
+			$parts[] = sprintf(
+				/* translators: %s: comma-separated list of top artists with play counts */
+				__( 'most-played: %s', 'jot' ),
+				implode( ', ', $top_parts )
+			);
+		}
+
+		$day_count = count( $days );
+		$sentence  = implode( '; ', $parts );
+		if ( $day_count > 1 ) {
+			$sentence .= ' ' . sprintf(
+				/* translators: %d: number of distinct days */
+				_n( '(across %d day).', '(across %d days).', $day_count, 'jot' ),
+				$day_count
+			);
+		} else {
+			$sentence .= '.';
+		}
+
+		return $sentence;
+	}
+}

--- a/jot.php
+++ b/jot.php
@@ -70,6 +70,7 @@ function jot_activate(): void {
 					'mastodon' => array( 'enabled' => false ),
 					'bluesky'  => array( 'enabled' => false ),
 					'strava'   => array( 'enabled' => false ),
+					'spotify'  => array( 'enabled' => false ),
 				),
 			)
 		);
@@ -153,7 +154,7 @@ function jot_services(): array {
 		return $services;
 	}
 	$services = array();
-	foreach ( array( 'Jot_Service_Github', 'Jot_Service_Strava' ) as $class ) {
+	foreach ( array( 'Jot_Service_Github', 'Jot_Service_Strava', 'Jot_Service_Spotify' ) as $class ) {
 		if ( class_exists( $class ) ) {
 			/** @var Jot_Service $instance */
 			$instance                   = new $class();


### PR DESCRIPTION
## Summary
- New `Jot_Service_Spotify` using the existing OAuth2 base (scope `user-read-recently-played user-read-email`).
- New `Jot_Signals_Spotify` aggregator: track count, unique artists, top-3 most-played with counts, and day spread.
- Registered in `jot_services()` and the activation defaults snapshot.

Follows the same pattern as GitHub/Strava. Administrators will add Spotify OAuth app credentials on the Connections page; users connect per-account from there.

## Test plan
- [ ] Register a Spotify OAuth app, save client_id/client_secret under Jot → Connections.
- [ ] Click Connect → Spotify; complete the OAuth dance; verify "Connected as {display_name}".
- [ ] Listen to a few tracks, then force a refresh and verify the widget shows a Spotify-sourced digest/suggestion.
- [ ] Disconnect removes the user meta and reverts status to "Not connected".
- [ ] Refresh-token path: wait for expiry or force `expires_at` into the past and confirm `authed_get()` transparently refreshes.

🤖 Generated with [Craft Agent](https://craft.do)