### PR TITLE
Add Todoist integration

### DIFF
--- a/includes/services/class-jot-service-todoist.php
+++ b/includes/services/class-jot-service-todoist.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Todoist service adapter.
+ *
+ * OAuth2 with a long-lived access token (no refresh token). We fetch the
+ * user's recently completed tasks via the Sync API.
+ *
+ * Docs:
+ *   https://developer.todoist.com/guides/#authorization
+ *   https://developer.todoist.com/sync/v9/#get-all-completed-items
+ *
+ * @package Jot
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+class Jot_Service_Todoist extends Jot_Service_OAuth2 {
+
+	public function __construct() {
+		$this->authorize_url    = 'https://todoist.com/oauth/authorize';
+		$this->access_token_url = 'https://todoist.com/oauth/access_token';
+		$this->scope            = 'data:read';
+		$this->auth_header_type = 'Bearer';
+	}
+
+	public function id(): string {
+		return 'todoist';
+	}
+
+	public function label(): string {
+		return __( 'Todoist', 'jot' );
+	}
+
+	protected function fetch_connection_meta( string $access_token ): array {
+		// Todoist has no dedicated "me" endpoint; the Sync API returns the user
+		// object when we request the "user" resource with sync_token=*.
+		$response = wp_remote_post(
+			'https://api.todoist.com/sync/v9/sync',
+			array(
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $access_token,
+					'Accept'        => 'application/json',
+					'User-Agent'    => 'Jot/' . JOT_VERSION . '; ' . home_url(),
+				),
+				'body'    => array(
+					'sync_token'     => '*',
+					'resource_types' => '["user"]',
+				),
+				'timeout' => 10,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return array();
+		}
+
+		$body = json_decode( (string) wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $body ) || empty( $body['user'] ) || ! is_array( $body['user'] ) ) {
+			return array();
+		}
+
+		$user = $body['user'];
+		$name = trim( (string) ( $user['full_name'] ?? '' ) );
+		return array(
+			'user_id'  => isset( $user['id'] ) ? (string) $user['id'] : '',
+			'username' => $name !== '' ? $name : (string) ( $user['email'] ?? '' ),
+			'name'     => $name,
+			'email'    => (string) ( $user['email'] ?? '' ),
+		);
+	}
+
+	public function fetch_recent( int $since, int $user_id ): array {
+		$url = add_query_arg(
+			array(
+				'since' => gmdate( 'Y-m-d\TH:i:s', $since ),
+				'limit' => 200,
+			),
+			'https://api.todoist.com/sync/v9/completed/get_all'
+		);
+
+		$response = $this->authed_get( $url, $user_id );
+		if ( is_wp_error( $response ) || ! is_array( $response ) || empty( $response['items'] ) || ! is_array( $response['items'] ) ) {
+			return array();
+		}
+
+		$projects = array();
+		if ( ! empty( $response['projects'] ) && is_array( $response['projects'] ) ) {
+			foreach ( $response['projects'] as $pid => $project ) {
+				if ( is_array( $project ) && ! empty( $project['name'] ) ) {
+					$projects[ (string) $pid ] = (string) $project['name'];
+				}
+			}
+		}
+
+		$out = array();
+		foreach ( $response['items'] as $item ) {
+			if ( ! is_array( $item ) || empty( $item['completed_at'] ) ) {
+				continue;
+			}
+			$completed_at = strtotime( (string) $item['completed_at'] );
+			if ( $completed_at === false ) {
+				continue;
+			}
+			$project_id = isset( $item['project_id'] ) ? (string) $item['project_id'] : '';
+			$out[] = array(
+				'content' => (string) ( $item['content'] ?? '' ),
+				'project' => $projects[ $project_id ] ?? '',
+				'at'      => $completed_at,
+			);
+		}
+		return $out;
+	}
+}

--- a/includes/signals/class-jot-signals-todoist.php
+++ b/includes/signals/class-jot-signals-todoist.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Todoist signal aggregator.
+ *
+ * Summarizes recently completed tasks with counts per project, e.g.
+ * "17 tasks completed across 4 projects; busiest: Inbox (9), Work (5)."
+ *
+ * @package Jot
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+class Jot_Signals_Todoist {
+
+	/**
+	 * @param array<int, array<string, mixed>> $tasks
+	 */
+	public static function aggregate( array $tasks ): string {
+		if ( empty( $tasks ) ) {
+			return '';
+		}
+
+		$total       = 0;
+		$by_project  = array();
+		$days        = array();
+		$samples     = array();
+
+		foreach ( $tasks as $t ) {
+			if ( ! is_array( $t ) ) {
+				continue;
+			}
+			$total++;
+			$project = (string) ( $t['project'] ?? '' );
+			if ( $project === '' ) {
+				$project = __( 'Untitled project', 'jot' );
+			}
+			$by_project[ $project ] = ( $by_project[ $project ] ?? 0 ) + 1;
+
+			$at = (int) ( $t['at'] ?? 0 );
+			if ( $at > 0 ) {
+				$days[ gmdate( 'Y-m-d', $at ) ] = true;
+			}
+
+			$content = trim( (string) ( $t['content'] ?? '' ) );
+			if ( $content !== '' && count( $samples ) < 3 ) {
+				$samples[] = $content;
+			}
+		}
+
+		if ( $total === 0 ) {
+			return '';
+		}
+
+		arsort( $by_project );
+		$project_count = count( $by_project );
+		$top           = array_slice( $by_project, 0, 2, true );
+
+		$top_parts = array();
+		foreach ( $top as $name => $count ) {
+			$top_parts[] = sprintf( '%s (%d)', $name, $count );
+		}
+
+		$parts   = array();
+		$parts[] = sprintf(
+			/* translators: 1: task count, 2: project count */
+			_n( '%1$d task completed across %2$d project', '%1$d tasks completed across %2$d projects', $total, 'jot' ),
+			$total,
+			$project_count
+		);
+
+		if ( ! empty( $top_parts ) ) {
+			$parts[] = sprintf(
+				/* translators: %s: comma-separated list of busiest projects */
+				__( 'busiest: %s', 'jot' ),
+				implode( ', ', $top_parts )
+			);
+		}
+
+		$sentence = implode( '; ', $parts );
+
+		$day_count = count( $days );
+		if ( $day_count > 1 ) {
+			$sentence .= ' ' . sprintf(
+				/* translators: %d: number of distinct days */
+				_n( '(across %d day).', '(across %d days).', $day_count, 'jot' ),
+				$day_count
+			);
+		} else {
+			$sentence .= '.';
+		}
+
+		return $sentence;
+	}
+}

--- a/jot.php
+++ b/jot.php
@@ -70,6 +70,7 @@ function jot_activate(): void {
 					'mastodon' => array( 'enabled' => false ),
 					'bluesky'  => array( 'enabled' => false ),
 					'strava'   => array( 'enabled' => false ),
+					'todoist'  => array( 'enabled' => false ),
 				),
 			)
 		);
@@ -153,7 +154,7 @@ function jot_services(): array {
 		return $services;
 	}
 	$services = array();
-	foreach ( array( 'Jot_Service_Github', 'Jot_Service_Strava' ) as $class ) {
+	foreach ( array( 'Jot_Service_Github', 'Jot_Service_Strava', 'Jot_Service_Todoist' ) as $class ) {
 		if ( class_exists( $class ) ) {
 			/** @var Jot_Service $instance */
 			$instance                   = new $class();


### PR DESCRIPTION
## Summary
- New \`Jot_Service_Todoist\` on the existing OAuth2 base (scope \`data:read\`). Todoist tokens are long-lived, so no refresh path.
- Fetches recently completed tasks via the Sync API (\`/sync/v9/completed/get_all\`) and resolves project names from the same response.
- New \`Jot_Signals_Todoist\` aggregator: total completed, project spread, busiest projects.
- Registered in \`jot_services()\` and activation defaults.

## Test plan
- [ ] Register a Todoist OAuth app, save client_id/client_secret.
- [ ] Connect → Todoist; confirm "Connected as {full_name or email}".
- [ ] Complete a few tasks across multiple projects; trigger widget refresh; verify digest mentions counts and busiest projects.
- [ ] Disconnect cleans up user meta.

🤖 Generated with [Craft Agent](https://craft.do)