### PR TITLE
Add Google Calendar integration

### DIFF
--- a/includes/services/class-jot-service-googlecalendar.php
+++ b/includes/services/class-jot-service-googlecalendar.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Google Calendar service adapter.
+ *
+ * OAuth2 with Google. We force `access_type=offline` and `prompt=consent`
+ * to reliably receive a refresh token on the first authorize — Google only
+ * returns one on the very first consent unless `prompt=consent` is sent.
+ *
+ * Docs:
+ *   https://developers.google.com/identity/protocols/oauth2/web-server
+ *   https://developers.google.com/calendar/api/v3/reference/events/list
+ *
+ * @package Jot
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+class Jot_Service_GoogleCalendar extends Jot_Service_OAuth2 {
+
+	public function __construct() {
+		$this->authorize_url    = 'https://accounts.google.com/o/oauth2/v2/auth';
+		$this->access_token_url = 'https://oauth2.googleapis.com/token';
+		$this->scope            = 'openid email profile https://www.googleapis.com/auth/calendar.readonly';
+		$this->auth_header_type = 'Bearer';
+
+		add_filter( 'jot_googlecalendar_authorize_params', array( $this, 'tune_authorize_params' ) );
+	}
+
+	/**
+	 * @param array<string, string> $params
+	 * @return array<string, string>
+	 */
+	public function tune_authorize_params( array $params ): array {
+		$params['access_type']            = 'offline';
+		$params['prompt']                 = 'consent';
+		$params['include_granted_scopes'] = 'true';
+		return $params;
+	}
+
+	public function id(): string {
+		return 'googlecalendar';
+	}
+
+	public function label(): string {
+		return __( 'Google Calendar', 'jot' );
+	}
+
+	protected function fetch_connection_meta( string $access_token ): array {
+		$response = wp_remote_get(
+			'https://www.googleapis.com/oauth2/v3/userinfo',
+			array(
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $access_token,
+					'Accept'        => 'application/json',
+					'User-Agent'    => 'Jot/' . JOT_VERSION . '; ' . home_url(),
+				),
+				'timeout' => 10,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return array();
+		}
+
+		$body = json_decode( (string) wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $body ) ) {
+			return array();
+		}
+
+		$name  = (string) ( $body['name'] ?? '' );
+		$email = (string) ( $body['email'] ?? '' );
+		return array(
+			'user_id'  => (string) ( $body['sub'] ?? '' ),
+			'username' => $name !== '' ? $name : $email,
+			'name'     => $name,
+			'email'    => $email,
+		);
+	}
+
+	public function fetch_recent( int $since, int $user_id ): array {
+		$url = add_query_arg(
+			array(
+				'timeMin'      => gmdate( 'c', $since ),
+				'timeMax'      => gmdate( 'c', time() ),
+				'singleEvents' => 'true',
+				'orderBy'      => 'startTime',
+				'maxResults'   => 250,
+			),
+			'https://www.googleapis.com/calendar/v3/calendars/primary/events'
+		);
+
+		$response = $this->authed_get( $url, $user_id );
+		if ( is_wp_error( $response ) || ! is_array( $response ) || empty( $response['items'] ) || ! is_array( $response['items'] ) ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $response['items'] as $event ) {
+			if ( ! is_array( $event ) || empty( $event['start'] ) || ! is_array( $event['start'] ) ) {
+				continue;
+			}
+
+			$start_raw = (string) ( $event['start']['dateTime'] ?? $event['start']['date'] ?? '' );
+			$start     = $start_raw !== '' ? strtotime( $start_raw ) : false;
+			if ( $start === false ) {
+				continue;
+			}
+
+			$end_raw      = (string) ( $event['end']['dateTime'] ?? $event['end']['date'] ?? '' );
+			$end          = $end_raw !== '' ? strtotime( $end_raw ) : false;
+			$all_day      = empty( $event['start']['dateTime'] );
+			$attendees    = is_array( $event['attendees'] ?? null ) ? count( $event['attendees'] ) : 0;
+
+			$out[] = array(
+				'summary'   => (string) ( $event['summary'] ?? '' ),
+				'at'        => $start,
+				'end'       => $end === false ? 0 : $end,
+				'all_day'   => $all_day,
+				'attendees' => $attendees,
+				'status'    => (string) ( $event['status'] ?? '' ),
+			);
+		}
+		return $out;
+	}
+}

--- a/includes/signals/class-jot-signals-googlecalendar.php
+++ b/includes/signals/class-jot-signals-googlecalendar.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Google Calendar signal aggregator.
+ *
+ * Summarizes recent events into meeting count, total hours, and a small
+ * sample of titles, e.g. "12 events over 5 days (≈7.5h in meetings);
+ * notable: Roadmap sync, 1:1 with Dana, Design review."
+ *
+ * @package Jot
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+class Jot_Signals_GoogleCalendar {
+
+	/**
+	 * @param array<int, array<string, mixed>> $events
+	 */
+	public static function aggregate( array $events ): string {
+		if ( empty( $events ) ) {
+			return '';
+		}
+
+		$count        = 0;
+		$meeting_secs = 0;
+		$days         = array();
+		$titles       = array();
+
+		foreach ( $events as $e ) {
+			if ( ! is_array( $e ) ) {
+				continue;
+			}
+			if ( ( $e['status'] ?? '' ) === 'cancelled' ) {
+				continue;
+			}
+			$count++;
+
+			$at = (int) ( $e['at'] ?? 0 );
+			if ( $at > 0 ) {
+				$days[ gmdate( 'Y-m-d', $at ) ] = true;
+			}
+
+			$end     = (int) ( $e['end'] ?? 0 );
+			$all_day = ! empty( $e['all_day'] );
+			if ( ! $all_day && $end > $at && $at > 0 ) {
+				$meeting_secs += ( $end - $at );
+			}
+
+			$summary = trim( (string) ( $e['summary'] ?? '' ) );
+			if ( $summary !== '' && count( $titles ) < 3 ) {
+				$titles[] = $summary;
+			}
+		}
+
+		if ( $count === 0 ) {
+			return '';
+		}
+
+		$day_count = max( 1, count( $days ) );
+		$hours     = $meeting_secs / 3600;
+
+		$parts   = array();
+		$parts[] = sprintf(
+			/* translators: 1: event count, 2: day count */
+			_n( '%1$d event over %2$d day', '%1$d events over %2$d days', $count, 'jot' ),
+			$count,
+			$day_count
+		);
+
+		if ( $hours >= 0.5 ) {
+			$parts[] = sprintf(
+				/* translators: %s: hours in meetings, formatted */
+				__( '≈%sh in meetings', 'jot' ),
+				$hours >= 10 ? number_format_i18n( $hours, 0 ) : number_format_i18n( $hours, 1 )
+			);
+		}
+
+		$sentence = implode( ' ', array( $parts[0], '(' . implode( '; ', array_slice( $parts, 1 ) ) . ')' ) );
+		if ( count( $parts ) === 1 ) {
+			$sentence = $parts[0];
+		}
+
+		if ( ! empty( $titles ) ) {
+			$sentence .= '; ' . sprintf(
+				/* translators: %s: comma-separated list of notable event titles */
+				__( 'notable: %s', 'jot' ),
+				implode( ', ', $titles )
+			);
+		}
+
+		return $sentence . '.';
+	}
+}

--- a/jot.php
+++ b/jot.php
@@ -68,10 +68,11 @@ function jot_activate(): void {
 				'services'         => array(
 					'github'   => array( 'enabled' => false ),
 					'mastodon' => array( 'enabled' => false ),
-					'bluesky'  => array( 'enabled' => false ),
-					'strava'   => array( 'enabled' => false ),
-					'todoist'  => array( 'enabled' => false ),
-					'spotify'  => array( 'enabled' => false ),
+					'bluesky'        => array( 'enabled' => false ),
+					'strava'         => array( 'enabled' => false ),
+					'todoist'        => array( 'enabled' => false ),
+					'spotify'        => array( 'enabled' => false ),
+					'googlecalendar' => array( 'enabled' => false ),
 				),
 			)
 		);
@@ -155,7 +156,7 @@ function jot_services(): array {
 		return $services;
 	}
 	$services = array();
-	foreach ( array( 'Jot_Service_Github', 'Jot_Service_Strava', 'Jot_Service_Spotify', 'Jot_Service_Todoist' ) as $class ) {
+	foreach ( array( 'Jot_Service_Github', 'Jot_Service_Strava', 'Jot_Service_Spotify', 'Jot_Service_Todoist', 'Jot_Service_GoogleCalendar' ) as $class ) {
 		if ( class_exists( $class ) ) {
 			/** @var Jot_Service $instance */
 			$instance                   = new $class();


### PR DESCRIPTION
## Summary
- New \`Jot_Service_GoogleCalendar\` on the OAuth2 base. Scopes: \`openid email profile https://www.googleapis.com/auth/calendar.readonly\`.
- Authorize params filter adds \`access_type=offline\` + \`prompt=consent\` so we reliably get a refresh token on first connect (Google only issues one on initial consent unless \`prompt=consent\` is set).
- Reads the primary calendar's events within the window via \`/calendar/v3/calendars/primary/events\`.
- New \`Jot_Signals_Googlecalendar\` aggregator: event count, day spread, total meeting hours (dateTime events only — all-day events are counted but not timed), and up to 3 notable titles.
- Registered in \`jot_services()\` and defaults.

## Test plan
- [ ] Create a Google Cloud OAuth client (Web app), add the Jot callback URL as an authorized redirect URI, enable Calendar API.
- [ ] Save client credentials; Connect → Google Calendar; verify "Connected as {name or email}".
- [ ] Confirm refresh_token was stored (first connect, thanks to \`prompt=consent\`). Force \`expires_at\` into the past and verify \`authed_get()\` refreshes transparently.
- [ ] Put a few events on the primary calendar; refresh widget; verify digest includes counts, meeting hours, and notable titles.
- [ ] Disconnect clears user meta.

🤖 Generated with [Craft Agent](https://craft.do)