### PR TITLE
Add YouTube integration

### DIFF
--- a/includes/services/class-jot-service-youtube.php
+++ b/includes/services/class-jot-service-youtube.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * YouTube service adapter.
+ *
+ * OAuth2 with Google. We read the user's "Liked videos" playlist (reserved
+ * id "LL") as the activity signal — recently-liked videos are a good proxy
+ * for what the user has been watching and reacting to.
+ *
+ * Docs:
+ *   https://developers.google.com/youtube/v3/guides/auth/server-side-web-apps
+ *   https://developers.google.com/youtube/v3/docs/playlistItems/list
+ *
+ * @package Jot
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+class Jot_Service_Youtube extends Jot_Service_OAuth2 {
+
+	public function __construct() {
+		$this->authorize_url    = 'https://accounts.google.com/o/oauth2/v2/auth';
+		$this->access_token_url = 'https://oauth2.googleapis.com/token';
+		$this->scope            = 'openid email profile https://www.googleapis.com/auth/youtube.readonly';
+		$this->auth_header_type = 'Bearer';
+
+		add_filter( 'jot_youtube_authorize_params', array( $this, 'tune_authorize_params' ) );
+	}
+
+	/**
+	 * @param array<string, string> $params
+	 * @return array<string, string>
+	 */
+	public function tune_authorize_params( array $params ): array {
+		$params['access_type']            = 'offline';
+		$params['prompt']                 = 'consent';
+		$params['include_granted_scopes'] = 'true';
+		return $params;
+	}
+
+	public function id(): string {
+		return 'youtube';
+	}
+
+	public function label(): string {
+		return __( 'YouTube', 'jot' );
+	}
+
+	protected function fetch_connection_meta( string $access_token ): array {
+		$response = wp_remote_get(
+			'https://www.googleapis.com/youtube/v3/channels?part=snippet&mine=true',
+			array(
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $access_token,
+					'Accept'        => 'application/json',
+					'User-Agent'    => 'Jot/' . JOT_VERSION . '; ' . home_url(),
+				),
+				'timeout' => 10,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return array();
+		}
+
+		$body = json_decode( (string) wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $body ) || empty( $body['items'] ) || ! is_array( $body['items'] ) ) {
+			return array();
+		}
+
+		$channel = $body['items'][0];
+		$snippet = is_array( $channel['snippet'] ?? null ) ? $channel['snippet'] : array();
+		$title   = (string) ( $snippet['title'] ?? '' );
+
+		return array(
+			'user_id'    => (string) ( $channel['id'] ?? '' ),
+			'username'   => $title,
+			'name'       => $title,
+			'channel_id' => (string) ( $channel['id'] ?? '' ),
+		);
+	}
+
+	public function fetch_recent( int $since, int $user_id ): array {
+		$url = add_query_arg(
+			array(
+				'part'       => 'snippet,contentDetails',
+				'playlistId' => 'LL',
+				'maxResults' => 50,
+			),
+			'https://www.googleapis.com/youtube/v3/playlistItems'
+		);
+
+		$response = $this->authed_get( $url, $user_id );
+		if ( is_wp_error( $response ) || ! is_array( $response ) || empty( $response['items'] ) || ! is_array( $response['items'] ) ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $response['items'] as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+			$snippet = is_array( $item['snippet'] ?? null ) ? $item['snippet'] : array();
+			$added   = strtotime( (string) ( $snippet['publishedAt'] ?? '' ) );
+			if ( $added === false || $added < $since ) {
+				continue;
+			}
+			$resource = is_array( $snippet['resourceId'] ?? null ) ? $snippet['resourceId'] : array();
+			$out[] = array(
+				'title'   => (string) ( $snippet['title'] ?? '' ),
+				'channel' => (string) ( $snippet['videoOwnerChannelTitle'] ?? '' ),
+				'video'   => (string) ( $resource['videoId'] ?? '' ),
+				'at'      => $added,
+			);
+		}
+		return $out;
+	}
+}

--- a/includes/signals/class-jot-signals-youtube.php
+++ b/includes/signals/class-jot-signals-youtube.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * YouTube signal aggregator.
+ *
+ * Summarizes recently liked videos with counts and top channels, e.g.
+ * "9 videos liked across 6 channels; most from: Veritasium (3), Kurzgesagt (2)."
+ *
+ * @package Jot
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+class Jot_Signals_Youtube {
+
+	/**
+	 * @param array<int, array<string, mixed>> $likes
+	 */
+	public static function aggregate( array $likes ): string {
+		if ( empty( $likes ) ) {
+			return '';
+		}
+
+		$total       = 0;
+		$by_channel  = array();
+		$titles      = array();
+
+		foreach ( $likes as $l ) {
+			if ( ! is_array( $l ) ) {
+				continue;
+			}
+			$total++;
+			$channel = trim( (string) ( $l['channel'] ?? '' ) );
+			if ( $channel !== '' ) {
+				$by_channel[ $channel ] = ( $by_channel[ $channel ] ?? 0 ) + 1;
+			}
+			$title = trim( (string) ( $l['title'] ?? '' ) );
+			if ( $title !== '' && count( $titles ) < 2 ) {
+				$titles[] = $title;
+			}
+		}
+
+		if ( $total === 0 ) {
+			return '';
+		}
+
+		arsort( $by_channel );
+		$channel_count = count( $by_channel );
+		$top           = array_slice( $by_channel, 0, 2, true );
+
+		$parts   = array();
+		$parts[] = sprintf(
+			/* translators: 1: video count, 2: channel count */
+			_n( '%1$d video liked across %2$d channel', '%1$d videos liked across %2$d channels', $total, 'jot' ),
+			$total,
+			$channel_count
+		);
+
+		if ( ! empty( $top ) ) {
+			$top_parts = array();
+			foreach ( $top as $name => $count ) {
+				$top_parts[] = sprintf( '%s (%d)', $name, $count );
+			}
+			$parts[] = sprintf(
+				/* translators: %s: comma-separated list of channels with like counts */
+				__( 'most from: %s', 'jot' ),
+				implode( ', ', $top_parts )
+			);
+		}
+
+		$sentence = implode( '; ', $parts );
+
+		if ( ! empty( $titles ) ) {
+			$sentence .= '; ' . sprintf(
+				/* translators: %s: comma-separated list of video titles */
+				__( 'including: %s', 'jot' ),
+				implode( ', ', $titles )
+			);
+		}
+
+		return $sentence . '.';
+	}
+}

--- a/jot.php
+++ b/jot.php
@@ -73,6 +73,7 @@ function jot_activate(): void {
 					'todoist'        => array( 'enabled' => false ),
 					'spotify'        => array( 'enabled' => false ),
 					'googlecalendar' => array( 'enabled' => false ),
+					'youtube'        => array( 'enabled' => false ),
 				),
 			)
 		);
@@ -156,7 +157,7 @@ function jot_services(): array {
 		return $services;
 	}
 	$services = array();
-	foreach ( array( 'Jot_Service_Github', 'Jot_Service_Strava', 'Jot_Service_Spotify', 'Jot_Service_Todoist', 'Jot_Service_GoogleCalendar' ) as $class ) {
+	foreach ( array( 'Jot_Service_Github', 'Jot_Service_Strava', 'Jot_Service_Spotify', 'Jot_Service_Todoist', 'Jot_Service_GoogleCalendar', 'Jot_Service_Youtube' ) as $class ) {
 		if ( class_exists( $class ) ) {
 			/** @var Jot_Service $instance */
 			$instance                   = new $class();


### PR DESCRIPTION
## Summary
- New \`Jot_Service_Youtube\` on the OAuth2 base. Scopes: \`openid email profile https://www.googleapis.com/auth/youtube.readonly\`.
- Authorize params force \`access_type=offline\` + \`prompt=consent\` for a reliable refresh token on first connect.
- Signal = recently liked videos from the user's reserved "LL" (Liked Videos) playlist via \`playlistItems.list\`. We filter by \`snippet.publishedAt >= since\` (i.e. when added to the playlist).
- New \`Jot_Signals_Youtube\` aggregator: count, channel spread, top channels, and a couple of video titles.
- Registered in \`jot_services()\` and defaults.

## Notes
- YouTube Data API has quota costs; \`playlistItems.list\` is 1 unit per call, plenty of headroom for daily refreshes.
- Identity comes from \`channels.list?mine=true\` (channel title), which is more natural than the Google userinfo name for a YouTube context.

## Test plan
- [ ] Google Cloud OAuth client with YouTube Data API v3 enabled; Jot callback registered as authorized redirect URI.
- [ ] Connect → YouTube; verify "Connected as {channel name}".
- [ ] Like a few videos; refresh widget; verify digest mentions counts and top channels.
- [ ] Refresh-token flow works (force \`expires_at\` into the past).
- [ ] Disconnect clears user meta.

🤖 Generated with [Craft Agent](https://craft.do)