### PR TITLE
Phase 5a: privacy hooks, readme.txt, contributor docs

### DIFF
--- a/docs/adding-a-service.md
+++ b/docs/adding-a-service.md
@@ -1,0 +1,107 @@
+# Adding a service to Jot
+
+This walks through adding a new service adapter (e.g. LinkedIn, Readwise, a custom internal API) so it shows up in Jot → Connections and participates in the daily refresh.
+
+A service comes in three pieces:
+
+1. **Service adapter** (`includes/services/class-jot-service-{id}.php`) — knows the OAuth details and API for one platform. Extends `Jot_Service_OAuth2` (or `Jot_Service` directly if you need non-OAuth2 auth).
+2. **Signal aggregator** (`includes/signals/class-jot-signals-{id}.php`) — turns raw events into one human-readable digest sentence. Has a single static method: `aggregate( array $events ): string`.
+3. **Registry entry** (in `jot.php::jot_services()`) — add your service class to the array.
+
+## 1. Service adapter
+
+Create `includes/services/class-jot-service-foo.php`. Minimum viable shape:
+
+```php
+<?php
+declare( strict_types=1 );
+defined( 'ABSPATH' ) || exit;
+
+class Jot_Service_Foo extends Jot_Service_OAuth2 {
+
+    public function __construct() {
+        $this->authorize_url    = 'https://example.com/oauth/authorize';
+        $this->access_token_url = 'https://example.com/oauth/token';
+        $this->scope            = 'read:activity';
+        $this->auth_header_type = 'Bearer'; // or 'token' for GitHub-style
+    }
+
+    public function id(): string    { return 'foo'; }
+    public function label(): string { return __( 'Foo', 'jot' ); }
+
+    protected function fetch_connection_meta( string $access_token ): array {
+        // Call /me equivalent; return ['username' => '...', 'name' => '...']
+    }
+
+    public function fetch_recent( int $since, int $user_id ): array {
+        $events = $this->authed_get( 'https://api.example.com/events', $user_id );
+        if ( is_wp_error( $events ) || ! is_array( $events ) ) {
+            return array();
+        }
+        // Normalize each event into a ['type', 'at' (unix), ...] shape.
+        return $events;
+    }
+}
+```
+
+### Notes on OAuth2 quirks
+
+The base handles the standard **authorize → code → access_token** flow, refresh tokens, and `state` CSRF protection. Two filters let you handle service-specific quirks without subclassing more:
+
+* `jot_{service}_authorize_params` — mutate the authorize params (e.g. add `approval_prompt=auto` for Strava).
+* `jot_{service}_authorize_url` — mutate the full authorize URL after `http_build_query()` (e.g. to preserve literal commas in a `scope` value — Strava rejects `%2C`).
+
+## 2. Signal aggregator
+
+Create `includes/signals/class-jot-signals-foo.php`:
+
+```php
+<?php
+declare( strict_types=1 );
+defined( 'ABSPATH' ) || exit;
+
+class Jot_Signals_Foo {
+    public static function aggregate( array $events ): string {
+        if ( empty( $events ) ) { return ''; }
+        // Produce one sentence. Group by meaningful unit
+        // (repo, activity type, channel, etc.).
+        return sprintf(
+            _n( '%d event in the last week.', '%d events in the last week.', count( $events ), 'jot' ),
+            count( $events )
+        );
+    }
+}
+```
+
+Keep the sentence compact — under ~150 characters is a good target. This is what the user sees *and* what the AI is given as context.
+
+## 3. Register the service
+
+In `jot.php`, inside `jot_services()`:
+
+```php
+foreach ( array( 'Jot_Service_Github', 'Jot_Service_Strava', 'Jot_Service_Foo' ) as $class ) {
+    ...
+}
+```
+
+## 4. Housekeeping
+
+* Add `jot_oauth_tokens_foo` to `uninstall.php`'s `$user_meta_keys`.
+* If your service needs a new default in `jot_activate()`'s `jot_settings.services` map, add it.
+* Add a Connections row — the Connections page auto-discovers everything registered in `jot_services()`, so if steps 1–3 are done, the row appears.
+
+## 5. Test
+
+1. Register an OAuth app on the service side. Use the callback URL shown in Jot → Connections for your service.
+2. Paste the Client ID / Secret into the admin section of Jot → Connections.
+3. Click Connect on your service's row; approve on the service side.
+4. Click Refresh in the dashboard widget. You should see a digest card for your service.
+5. (With AI configured) After refresh, your service's digest should feature in the AI's suggestion cards via the `sources` array.
+
+## Conventions
+
+* **Don't fetch on render.** All remote calls happen in the cron path (daily) or via the debounced manual refresh — never on dashboard load.
+* **Return WP_Error, don't throw.** Every adapter method that can fail should return a WP_Error with a helpful message. The base class surfaces these in the admin AI-debug panel.
+* **Normalize timestamps to Unix seconds.** Jot's cron windows work in Unix time.
+* **Per-user, always.** Tokens live in user meta. App credentials live in a site-wide option.

--- a/includes/privacy/class-jot-privacy.php
+++ b/includes/privacy/class-jot-privacy.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * Jot personal-data exporter + eraser hooks.
+ *
+ * Integrates with WordPress's Tools → Export Personal Data / Erase Personal
+ * Data screens so a site admin can fulfill data-subject requests using Jot's
+ * per-user state.
+ *
+ * What we expose to the exporter:
+ *   - Connected service metadata (service label + remote username + connected-at).
+ *     Raw access tokens are NOT exported — they're credentials, not user-authored data.
+ *   - Activity digests generated for the user.
+ *   - AI suggestion cards generated for the user.
+ *   - Jot-authored post metadata (_jot_source, _jot_tier, _jot_signals).
+ *
+ * What the eraser removes:
+ *   - Every jot_* user-meta entry (tokens included — OAuth connection is revoked).
+ *   - Jot-specific post meta on drafts. The drafts themselves are user-authored
+ *     posts and are not deleted by Jot's eraser; WP core's own post eraser
+ *     handles author posts if requested separately.
+ *
+ * @package Jot
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+class Jot_Privacy {
+
+	public const EXPORTER_ID = 'jot';
+	public const ERASER_ID   = 'jot';
+
+	public static function boot(): void {
+		add_filter( 'wp_privacy_personal_data_exporters', array( __CLASS__, 'register_exporter' ) );
+		add_filter( 'wp_privacy_personal_data_erasers', array( __CLASS__, 'register_eraser' ) );
+	}
+
+	/**
+	 * @param array<string, array<string, mixed>> $exporters
+	 * @return array<string, array<string, mixed>>
+	 */
+	public static function register_exporter( array $exporters ): array {
+		$exporters[ self::EXPORTER_ID ] = array(
+			'exporter_friendly_name' => __( 'Jot', 'jot' ),
+			'callback'               => array( __CLASS__, 'export' ),
+		);
+		return $exporters;
+	}
+
+	/**
+	 * @param array<string, array<string, mixed>> $erasers
+	 * @return array<string, array<string, mixed>>
+	 */
+	public static function register_eraser( array $erasers ): array {
+		$erasers[ self::ERASER_ID ] = array(
+			'eraser_friendly_name' => __( 'Jot', 'jot' ),
+			'callback'             => array( __CLASS__, 'erase' ),
+		);
+		return $erasers;
+	}
+
+	/**
+	 * @return array{data:array<int, array<string,mixed>>, done:bool}
+	 */
+	public static function export( string $email_address, int $page = 1 ): array {
+		$user = get_user_by( 'email', $email_address );
+		if ( ! $user ) {
+			return array( 'data' => array(), 'done' => true );
+		}
+		$user_id = (int) $user->ID;
+		$items   = array();
+
+		// Connections (service + username + stored_at; no tokens).
+		foreach ( self::user_meta_keys_prefixed( $user_id, 'jot_oauth_tokens_' ) as $meta_key => $value ) {
+			$service_id = substr( $meta_key, strlen( 'jot_oauth_tokens_' ) );
+			$username   = is_array( $value ) && isset( $value['meta']['username'] ) ? (string) $value['meta']['username'] : '';
+			$stored_at  = is_array( $value ) && isset( $value['stored_at'] ) ? (int) $value['stored_at'] : 0;
+
+			$data = array(
+				array( 'name' => __( 'Service', 'jot' ), 'value' => $service_id ),
+			);
+			if ( $username !== '' ) {
+				$data[] = array( 'name' => __( 'Remote username', 'jot' ), 'value' => $username );
+			}
+			if ( $stored_at > 0 ) {
+				$data[] = array( 'name' => __( 'Connected at', 'jot' ), 'value' => wp_date( 'c', $stored_at ) );
+			}
+			$items[] = array(
+				'group_id'    => 'jot-connections',
+				'group_label' => __( 'Jot — Connections', 'jot' ),
+				'item_id'     => 'jot-connection-' . $service_id,
+				'data'        => $data,
+			);
+		}
+
+		// Cached digests.
+		$digests = jot_get_user_array( $user_id, Jot_Cron::USER_DIGESTS_META );
+		foreach ( $digests as $i => $digest ) {
+			if ( ! is_array( $digest ) ) {
+				continue;
+			}
+			$items[] = array(
+				'group_id'    => 'jot-digests',
+				'group_label' => __( 'Jot — Activity digests', 'jot' ),
+				'item_id'     => 'jot-digest-' . (int) $i,
+				'data'        => array(
+					array( 'name' => __( 'Service', 'jot' ), 'value' => (string) ( $digest['service'] ?? '' ) ),
+					array( 'name' => __( 'Digest', 'jot' ), 'value' => (string) ( $digest['digest'] ?? '' ) ),
+				),
+			);
+		}
+
+		// AI suggestion cards.
+		$cards = jot_get_user_array( $user_id, Jot_Cron::USER_CARDS_META );
+		foreach ( $cards as $i => $card ) {
+			if ( ! is_array( $card ) ) {
+				continue;
+			}
+			$items[] = array(
+				'group_id'    => 'jot-cards',
+				'group_label' => __( 'Jot — Suggestion cards', 'jot' ),
+				'item_id'     => 'jot-card-' . (int) $i,
+				'data'        => array(
+					array( 'name' => __( 'Title', 'jot' ),     'value' => (string) ( $card['title'] ?? '' ) ),
+					array( 'name' => __( 'Rationale', 'jot' ), 'value' => (string) ( $card['rationale'] ?? '' ) ),
+					array( 'name' => __( 'Sources', 'jot' ),   'value' => implode( ', ', (array) ( $card['labels'] ?? array() ) ) ),
+				),
+			);
+		}
+
+		// Jot-authored post meta on user's drafts.
+		$posts = get_posts(
+			array(
+				'post_type'      => 'post',
+				'post_status'    => 'any',
+				'author'         => $user_id,
+				'posts_per_page' => 50,
+				'meta_key'       => '_jot_source',
+				'no_found_rows'  => true,
+			)
+		);
+		foreach ( $posts as $post ) {
+			$items[] = array(
+				'group_id'    => 'jot-posts',
+				'group_label' => __( 'Jot — Drafts authored from Jot', 'jot' ),
+				'item_id'     => 'jot-post-' . (int) $post->ID,
+				'data'        => array(
+					array( 'name' => __( 'Post', 'jot' ),    'value' => get_edit_post_link( $post, 'raw' ) ),
+					array( 'name' => __( 'Source', 'jot' ),  'value' => (string) get_post_meta( $post->ID, '_jot_source', true ) ),
+					array( 'name' => __( 'Tier', 'jot' ),    'value' => (string) get_post_meta( $post->ID, '_jot_tier', true ) ),
+					array( 'name' => __( 'Signals', 'jot' ), 'value' => (string) get_post_meta( $post->ID, '_jot_signals', true ) ),
+				),
+			);
+		}
+
+		return array( 'data' => $items, 'done' => true );
+	}
+
+	/**
+	 * @return array{items_removed:int, items_retained:int, messages:array<int,string>, done:bool}
+	 */
+	public static function erase( string $email_address, int $page = 1 ): array {
+		$user = get_user_by( 'email', $email_address );
+		if ( ! $user ) {
+			return array(
+				'items_removed'  => 0,
+				'items_retained' => 0,
+				'messages'       => array(),
+				'done'           => true,
+			);
+		}
+		$user_id = (int) $user->ID;
+		$removed = 0;
+
+		foreach ( self::jot_user_meta_keys() as $key ) {
+			if ( metadata_exists( 'user', $user_id, $key ) ) {
+				delete_user_meta( $user_id, $key );
+				$removed++;
+			}
+		}
+
+		// Also clear any per-service OAuth token keys we don't know about upfront
+		// (future services).
+		foreach ( self::user_meta_keys_prefixed( $user_id, 'jot_oauth_tokens_' ) as $meta_key => $_value ) {
+			delete_user_meta( $user_id, $meta_key );
+			$removed++;
+		}
+
+		// Strip Jot-specific post meta from user's posts. The posts themselves
+		// are user-authored; core's post eraser handles those if asked.
+		$posts = get_posts(
+			array(
+				'post_type'      => 'post',
+				'post_status'    => 'any',
+				'author'         => $user_id,
+				'posts_per_page' => -1,
+				'meta_key'       => '_jot_source',
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+			)
+		);
+		foreach ( $posts as $post_id ) {
+			foreach ( array( '_jot_source', '_jot_tier', '_jot_signals' ) as $meta ) {
+				if ( metadata_exists( 'post', $post_id, $meta ) ) {
+					delete_post_meta( $post_id, $meta );
+					$removed++;
+				}
+			}
+		}
+
+		return array(
+			'items_removed'  => $removed,
+			'items_retained' => 0,
+			'messages'       => array(),
+			'done'           => true,
+		);
+	}
+
+	/**
+	 * @return array<int, string>
+	 */
+	private static function jot_user_meta_keys(): array {
+		return array(
+			Jot_Cron::USER_DIGESTS_META,
+			Jot_Cron::USER_CARDS_META,
+			Jot_Cron::USER_LAST_REFRESH,
+			Jot_Cron::USER_AI_ERROR_META,
+			Jot_Ai::DEBUG_META,
+			Jot_Cron::USER_ACTED_ON_META,
+			Jot_Cron::USER_DISMISSED_META,
+		);
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private static function user_meta_keys_prefixed( int $user_id, string $prefix ): array {
+		global $wpdb;
+		$like = $wpdb->esc_like( $prefix ) . '%';
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT meta_key, meta_value FROM {$wpdb->usermeta} WHERE user_id = %d AND meta_key LIKE %s",
+				$user_id,
+				$like
+			),
+			ARRAY_A
+		);
+		$out = array();
+		foreach ( (array) $rows as $row ) {
+			$out[ (string) $row['meta_key'] ] = maybe_unserialize( $row['meta_value'] );
+		}
+		return $out;
+	}
+}

--- a/jot.php
+++ b/jot.php
@@ -37,6 +37,7 @@ spl_autoload_register(
 			JOT_PLUGIN_DIR . 'includes/admin/' . $file,
 			JOT_PLUGIN_DIR . 'includes/cron/' . $file,
 			JOT_PLUGIN_DIR . 'includes/rest/' . $file,
+			JOT_PLUGIN_DIR . 'includes/privacy/' . $file,
 			JOT_PLUGIN_DIR . 'includes/signals/' . $file,
 			JOT_PLUGIN_DIR . 'includes/ai/' . $file,
 			JOT_PLUGIN_DIR . 'includes/services/' . $file,
@@ -101,6 +102,9 @@ function jot_boot_subsystems(): void {
 	}
 	if ( class_exists( 'Jot_Connections_Page' ) ) {
 		Jot_Connections_Page::boot();
+	}
+	if ( class_exists( 'Jot_Privacy' ) ) {
+		Jot_Privacy::boot();
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -8,21 +8,92 @@ Stable tag: 0.1.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-A dashboard widget that surfaces post-idea suggestions drawn from your activity on connected services.
+A dashboard widget that turns your activity on connected services into post-idea suggestions. Works without AI; even better with one.
 
 == Description ==
 
-Jot adds a dashboard widget that suggests blog post angles based on your activity on services like GitHub, Mastodon, Bluesky, and Strava. Without AI it shows aggregated digests; with an AI provider connected through the WordPress 7.0 Connectors API it produces titled suggestion cards with three output tiers: quick spark, outline, or full draft.
+Jot watches what you do on the services you connect — GitHub commits, Strava activities — and pulls that activity into your WordPress dashboard as post-idea suggestions. You always choose what becomes a real post.
 
-Jot never auto-publishes. Every draft is a user-initiated click.
+Shaped after WordPress's built-in Quick Draft, Jot shows a compact list of suggestions plus your recent Jot-generated drafts, all without leaving /wp-admin.
+
+= Two modes =
+
+**Without AI.** Jot shows raw activity digests per service — "7 commits across 3 days to rust-analyzer", "3 runs totaling 24 km across 4 days". One click turns a digest into a WordPress draft pre-populated with that context.
+
+**With AI** (via WordPress 7.0's Connectors API or the wp-ai-client plugin on older cores). Jot composes titled suggestion cards that weave multiple services together, and every card offers three output tiers:
+
+* **Quick spark** — title plus a 1–2 sentence summary.
+* **Outline** — title plus 3–5 section headings with intent.
+* **Full draft** — title plus a complete first-draft post in blocks.
+
+Every tier is a one-click action; the writer stays in control.
+
+= Principles =
+
+* **Respect the writer.** AI provides scaffolding, not finished work. Nothing is auto-published.
+* **Predictable cost.** One daily AI call per user. Manual refresh debounced.
+* **Graceful degradation.** Jot remains useful without AI.
+* **Provider-agnostic.** Works with any AI provider the Connectors API surfaces.
+
+= v1 services =
+
+* **GitHub** — commits, pull requests, starred repos.
+* **Strava** — activities (runs, rides, swims, etc.).
+* **Mastodon** — coming soon.
+* **Bluesky** — coming soon.
 
 == Installation ==
 
 1. Upload the `jot` folder to `/wp-content/plugins/`.
 2. Activate Jot in the Plugins admin screen.
-3. Visit Jot → Connections to link a service (coming in Phase 2).
+3. Visit **Jot → Connections**, paste your OAuth app credentials for each service you want to use, then click **Connect** to authorize your own account.
+4. (Optional) In **Settings → AI Credentials**, configure an AI provider.
+
+== Frequently Asked Questions ==
+
+= Does Jot ever publish posts automatically? =
+
+No. Every draft is a user-initiated click. Jot never calls `wp_publish_post()` or similar. The three tier buttons create drafts only.
+
+= Is Jot per-user or site-wide? =
+
+Service connections are per-user: your GitHub and Strava tokens are never shared with other users on the same site. OAuth *app* credentials (Client ID / Secret) are site-wide and set by an administrator once.
+
+= What data leaves my site? =
+
+* When a cron or manual refresh runs, Jot calls the connected services' public APIs with your user token to fetch recent activity.
+* When AI is configured and a refresh runs, Jot sends the aggregated activity digests plus your last 20 post titles (plus your optional voice/style hint from Settings) to the configured AI provider to generate suggestion cards.
+* Clicking **Quick spark**, **Outline**, or **Full draft** sends the card's context to the AI provider to generate the post.
+* No other data leaves your site.
+
+= Do you store my OAuth tokens? =
+
+Yes, in your user meta — scoped to your user account, not shared site-wide. Tokens are used only to fetch your own activity from the connected services. Disconnecting or uninstalling removes them.
+
+= Does Jot work without an AI provider? =
+
+Yes. Each service's activity renders as a plain-English digest and you can turn any digest into a WordPress draft in one click.
+
+= Which WordPress versions are supported? =
+
+Jot targets WordPress 7.0+ (AI Connectors API) and PHP 8.1+. Older WordPress versions can use Jot via the `wp-ai-client` plugin for AI features; the non-AI flow works anywhere.
+
+= How is my data handled for GDPR / data-subject requests? =
+
+Jot registers personal-data exporter and eraser hooks so administrators can fulfill requests via **Tools → Export Personal Data** and **Tools → Erase Personal Data**. The exporter includes connections, activity digests, suggestion cards, and Jot-specific post meta. The eraser removes all per-user Jot meta and strips Jot meta from posts; Jot does not delete the posts themselves.
+
+== Privacy ==
+
+Jot is designed to keep your data under your control:
+
+* All connection state is per-user.
+* No activity or suggestion data is shared between users on the same site.
+* No analytics, telemetry, or third-party trackers are bundled.
+* Data sent to AI providers is limited to what's needed to generate a card or tier: per-service digest text, recent post titles, and the optional voice hint.
+
+For a full accounting, see the FAQ above.
 
 == Changelog ==
 
 = 0.1.0 =
-* Initial scaffold: plugin bootstrap, dashboard widget shell, Connections and Settings admin pages.
+* Initial release: dashboard widget, GitHub + Strava adapters, AI integration with three tiers, XHR refresh, dismiss / acted-on suppression, privacy exporter + eraser hooks.


### PR DESCRIPTION
## Summary

First slice of WP.org readiness work. Three discrete, low-risk pieces:

1. **Privacy exporter + eraser hooks** — integrates with WP's built-in Tools → Export Personal Data / Erase Personal Data. Exporter returns connections (no raw tokens), activity digests, suggestion cards, and Jot-specific post meta. Eraser removes every \`jot_*\` user meta entry (including OAuth tokens — connections are revoked) plus the Jot meta from the user's posts. Posts themselves are not deleted (they're user-authored; core's post eraser handles that if asked).
2. **readme.txt expansion** — real WP.org-style description, two-mode positioning (with/without AI), FAQ covering auto-publishing / per-user state / data-leaving-the-site / OAuth tokens / privacy rights, privacy section, and a 0.1.0 changelog.
3. **Contributor docs** — \`docs/adding-a-service.md\` walks through the three pieces (adapter / signal / registry) needed to add a new service, plus OAuth2 quirk filter hooks and conventions.

## What's still pending for Phase 5b

- A11y audit with manual SR testing
- Screenshots for the WP.org listing (needs manual capture from a real install)
- .pot generation in CI (wp i18n make-pot via GitHub Actions)

## Test plan

- [ ] Plugin activates cleanly; no fatals on a fresh install.
- [ ] Tools → Export Personal Data — create a request for your own email, approve; downloaded ZIP contains \`jot-connections\`, \`jot-digests\`, \`jot-cards\`, and \`jot-posts\` groups populated with your data.
- [ ] Tools → Erase Personal Data — create a request; after approval all \`jot_*\` user meta is gone (verify with \`wp user meta list <id>\`), and \`_jot_source\`/\`_jot_tier\`/\`_jot_signals\` are stripped from your posts. Posts themselves are retained.
- [ ] readme.txt parses OK via the WP.org readme validator.

🤖 Generated with [Craft Agent](https://craft.do)