### PR TITLE
Add Bluesky integration (app-password auth)

### DIFF
--- a/includes/admin/class-jot-connections-page.php
+++ b/includes/admin/class-jot-connections-page.php
@@ -31,6 +31,7 @@ class Jot_Connections_Page {
 		$instance = new self();
 		add_action( 'admin_post_jot_save_oauth_apps', array( $instance, 'handle_save_apps' ) );
 		add_action( 'admin_post_jot_disconnect_service', array( $instance, 'handle_disconnect' ) );
+		add_action( 'admin_post_jot_save_credentials', array( $instance, 'handle_save_credentials' ) );
 	}
 
 	public function register(): void {
@@ -70,6 +71,9 @@ class Jot_Connections_Page {
 			: array();
 
 		foreach ( jot_services() as $service ) {
+			if ( $service instanceof Jot_Service_Credentials ) {
+				continue;
+			}
 			$id           = $service->id();
 			$client_id    = isset( $submitted[ $id ]['client_id'] ) ? sanitize_text_field( (string) $submitted[ $id ]['client_id'] ) : '';
 			$client_secret_input = isset( $submitted[ $id ]['client_secret'] ) ? (string) $submitted[ $id ]['client_secret'] : '';
@@ -83,6 +87,45 @@ class Jot_Connections_Page {
 
 		update_option( self::APPS_OPTION_KEY, $existing, false );
 		wp_safe_redirect( add_query_arg( 'updated', '1', admin_url( 'admin.php?page=' . self::MENU_SLUG ) ) );
+		exit;
+	}
+
+	public function handle_save_credentials(): void {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_die( esc_html__( 'Insufficient permissions.', 'jot' ) );
+		}
+		$service_id = isset( $_REQUEST['service'] ) ? sanitize_key( (string) wp_unslash( $_REQUEST['service'] ) ) : '';
+		check_admin_referer( 'jot-credentials-' . $service_id );
+
+		$services = jot_services();
+		$service  = $services[ $service_id ] ?? null;
+		if ( ! $service instanceof Jot_Service_Credentials ) {
+			wp_safe_redirect( add_query_arg( 'credentials_error', 'unknown', admin_url( 'admin.php?page=' . self::MENU_SLUG ) ) );
+			exit;
+		}
+
+		$fields = array();
+		if ( isset( $_POST['jot_credentials'] ) && is_array( $_POST['jot_credentials'] ) ) {
+			foreach ( wp_unslash( $_POST['jot_credentials'] ) as $key => $value ) {
+				$fields[ (string) $key ] = is_scalar( $value ) ? (string) $value : '';
+			}
+		}
+
+		$result = $service->authenticate( $fields, get_current_user_id() );
+		if ( is_wp_error( $result ) ) {
+			$url = add_query_arg(
+				array(
+					'page'              => self::MENU_SLUG,
+					'jot_credentials'   => $service_id,
+					'credentials_error' => rawurlencode( $result->get_error_message() ),
+				),
+				admin_url( 'admin.php' )
+			);
+			wp_safe_redirect( $url );
+			exit;
+		}
+
+		wp_safe_redirect( add_query_arg( 'connected', $service_id, admin_url( 'admin.php?page=' . self::MENU_SLUG ) ) );
 		exit;
 	}
 
@@ -126,6 +169,56 @@ class Jot_Connections_Page {
 					<p><?php echo esc_html( sprintf( /* translators: %s: service id */ __( 'Disconnected: %s', 'jot' ), sanitize_key( (string) wp_unslash( $_GET['disconnected'] ) ) ) ); ?></p>
 				</div>
 			<?php endif; ?>
+			<?php if ( ! empty( $_GET['credentials_error'] ) ) : ?>
+				<div class="notice notice-error is-dismissible">
+					<p><?php echo esc_html( rawurldecode( (string) wp_unslash( $_GET['credentials_error'] ) ) ); ?></p>
+				</div>
+			<?php endif; ?>
+
+			<?php
+			$credentials_target = isset( $_GET['jot_credentials'] ) ? sanitize_key( (string) wp_unslash( $_GET['jot_credentials'] ) ) : '';
+			$services_map       = jot_services();
+			if ( $credentials_target !== '' && isset( $services_map[ $credentials_target ] ) && $services_map[ $credentials_target ] instanceof Jot_Service_Credentials ) :
+				$cred_service = $services_map[ $credentials_target ];
+				?>
+				<h2><?php echo esc_html( sprintf( /* translators: %s: service label */ __( 'Connect %s', 'jot' ), $cred_service->label() ) ); ?></h2>
+				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+					<input type="hidden" name="action" value="jot_save_credentials" />
+					<input type="hidden" name="service" value="<?php echo esc_attr( $cred_service->id() ); ?>" />
+					<?php wp_nonce_field( 'jot-credentials-' . $cred_service->id() ); ?>
+					<table class="form-table" role="presentation">
+						<tbody>
+							<?php foreach ( $cred_service->credential_fields() as $field ) :
+								$key  = (string) ( $field['key'] ?? '' );
+								$type = (string) ( $field['type'] ?? 'text' );
+								if ( $key === '' ) {
+									continue;
+								}
+								?>
+								<tr>
+									<th scope="row"><label for="jot-cred-<?php echo esc_attr( $key ); ?>"><?php echo esc_html( (string) ( $field['label'] ?? $key ) ); ?></label></th>
+									<td>
+										<input
+											type="<?php echo esc_attr( $type === 'password' ? 'password' : 'text' ); ?>"
+											id="jot-cred-<?php echo esc_attr( $key ); ?>"
+											class="regular-text"
+											name="jot_credentials[<?php echo esc_attr( $key ); ?>]"
+											placeholder="<?php echo esc_attr( (string) ( $field['placeholder'] ?? '' ) ); ?>"
+											autocomplete="off"
+										/>
+										<?php if ( ! empty( $field['help'] ) ) : ?>
+											<p class="description"><?php echo esc_html( (string) $field['help'] ); ?></p>
+										<?php endif; ?>
+									</td>
+								</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
+					<?php submit_button( __( 'Connect', 'jot' ) ); ?>
+					<a class="button" href="<?php echo esc_url( admin_url( 'admin.php?page=' . self::MENU_SLUG ) ); ?>"><?php esc_html_e( 'Cancel', 'jot' ); ?></a>
+				</form>
+				<hr style="margin:32px 0;" />
+			<?php endif; ?>
 
 			<h2><?php esc_html_e( 'Your connections', 'jot' ); ?></h2>
 			<p class="description"><?php esc_html_e( 'Connections are per-user. Your tokens are never shared with other users on this site.', 'jot' ); ?></p>
@@ -140,10 +233,12 @@ class Jot_Connections_Page {
 				</thead>
 				<tbody>
 					<?php foreach ( jot_services() as $service ) :
-						$id         = $service->id();
-						$status     = $service->status( get_current_user_id() );
-						$configured = ! empty( $apps[ $id ]['client_id'] ) && ! empty( $apps[ $id ]['client_secret'] );
-						$connected  = ! empty( $status['connected'] );
+						$id             = $service->id();
+						$status         = $service->status( get_current_user_id() );
+						$is_credentials = $service instanceof Jot_Service_Credentials;
+						// Credential-based services don't need site-wide OAuth app configuration.
+						$configured     = $is_credentials || ( ! empty( $apps[ $id ]['client_id'] ) && ! empty( $apps[ $id ]['client_secret'] ) );
+						$connected      = ! empty( $status['connected'] );
 						?>
 						<tr>
 							<td><strong><?php echo esc_html( $service->label() ); ?></strong></td>
@@ -210,6 +305,10 @@ class Jot_Connections_Page {
 					<table class="form-table" role="presentation">
 						<tbody>
 							<?php foreach ( jot_services() as $service ) :
+								// Credential-based services (e.g. Bluesky) don't use a shared OAuth app.
+								if ( $service instanceof Jot_Service_Credentials ) {
+									continue;
+								}
 								$id       = $service->id();
 								$current  = isset( $apps[ $id ] ) && is_array( $apps[ $id ] ) ? $apps[ $id ] : array();
 								$callback = $service->callback_url();

--- a/includes/oauth/class-jot-service-credentials.php
+++ b/includes/oauth/class-jot-service-credentials.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Credentials-based service adapter.
+ *
+ * Some services don't use OAuth — the user pastes a handle + app password (or
+ * API key) instead. This base hooks into the Connections UI by redirecting
+ * the normal "Connect" button to a credential entry form rather than an
+ * OAuth authorize URL; the form POSTs back to `jot_save_credentials`, which
+ * delegates to `authenticate()` on the service.
+ *
+ * Stored token shape matches Jot_Service (access_token + meta + stored_at),
+ * so downstream code (`status`, `get_token`) just works.
+ *
+ * @package Jot
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+abstract class Jot_Service_Credentials extends Jot_Service {
+
+	/**
+	 * Form definition for the credential entry page.
+	 *
+	 * @return array<int, array{key:string, label:string, type:string, help?:string, placeholder?:string}>
+	 */
+	abstract public function credential_fields(): array;
+
+	/**
+	 * Exchange the submitted credentials for an access token and persist it.
+	 *
+	 * @param array<string, string> $fields  Raw submitted values (already unslashed, not yet sanitized).
+	 * @param int                   $user_id Current user id.
+	 * @return true|WP_Error
+	 */
+	abstract public function authenticate( array $fields, int $user_id );
+
+	/**
+	 * "Connect" redirects here, which in turn bounces to the Connections page
+	 * with a query param that causes the credential form to render.
+	 */
+	public function connect(): void {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_die( esc_html__( 'You do not have permission to connect services.', 'jot' ) );
+		}
+		check_admin_referer( 'jot-connect-' . $this->id() );
+
+		$url = add_query_arg(
+			array(
+				'page'             => 'jot-connections',
+				'jot_credentials'  => $this->id(),
+			),
+			admin_url( 'admin.php' )
+		);
+		wp_safe_redirect( $url );
+		exit;
+	}
+
+	/**
+	 * No OAuth callback for credentials-based services.
+	 */
+	public function handle_callback(): void {
+		wp_safe_redirect( admin_url( 'admin.php?page=jot-connections' ) );
+		exit;
+	}
+
+	public function status( int $user_id ): array {
+		$token = $this->get_token( $user_id );
+		if ( ! $token ) {
+			return array( 'connected' => false );
+		}
+		$username = (string) ( $token['meta']['username'] ?? '' );
+		return array(
+			'connected' => true,
+			'user'      => $username,
+		);
+	}
+}

--- a/includes/services/class-jot-service-bluesky.php
+++ b/includes/services/class-jot-service-bluesky.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * Bluesky service adapter.
+ *
+ * Uses an app password (Bluesky Settings → Privacy and security → App
+ * passwords). We exchange the handle + app password for a session via
+ * `com.atproto.server.createSession`, store the accessJwt + refreshJwt,
+ * and refresh on 401 via `com.atproto.server.refreshSession`.
+ *
+ * Docs:
+ *   https://docs.bsky.app/docs/advanced-guides/app-passwords
+ *   https://docs.bsky.app/docs/api/com-atproto-server-create-session
+ *   https://docs.bsky.app/docs/api/app-bsky-feed-get-author-feed
+ *
+ * @package Jot
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+class Jot_Service_Bluesky extends Jot_Service_Credentials {
+
+	private const DEFAULT_SERVICE = 'https://bsky.social';
+
+	public function id(): string {
+		return 'bluesky';
+	}
+
+	public function label(): string {
+		return __( 'Bluesky', 'jot' );
+	}
+
+	public function credential_fields(): array {
+		return array(
+			array(
+				'key'         => 'handle',
+				'label'       => __( 'Handle', 'jot' ),
+				'type'        => 'text',
+				'placeholder' => 'you.bsky.social',
+				'help'        => __( 'Your Bluesky handle, without the leading @.', 'jot' ),
+			),
+			array(
+				'key'         => 'app_password',
+				'label'       => __( 'App password', 'jot' ),
+				'type'        => 'password',
+				'help'        => __( 'Create one at bsky.app → Settings → Privacy and security → App passwords. Do not use your account password.', 'jot' ),
+			),
+		);
+	}
+
+	public function authenticate( array $fields, int $user_id ) {
+		$handle       = sanitize_text_field( (string) ( $fields['handle'] ?? '' ) );
+		$app_password = trim( (string) ( $fields['app_password'] ?? '' ) );
+		$handle       = ltrim( $handle, '@' );
+
+		if ( $handle === '' || $app_password === '' ) {
+			return new WP_Error( 'jot_bluesky_missing_fields', __( 'Handle and app password are both required.', 'jot' ) );
+		}
+
+		$response = wp_remote_post(
+			self::DEFAULT_SERVICE . '/xrpc/com.atproto.server.createSession',
+			array(
+				'headers' => array(
+					'Content-Type' => 'application/json',
+					'Accept'       => 'application/json',
+					'User-Agent'   => 'Jot/' . JOT_VERSION . '; ' . home_url(),
+				),
+				'body'    => wp_json_encode(
+					array(
+						'identifier' => $handle,
+						'password'   => $app_password,
+					)
+				),
+				'timeout' => 15,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+		$status = (int) wp_remote_retrieve_response_code( $response );
+		$body   = json_decode( (string) wp_remote_retrieve_body( $response ), true );
+		if ( $status < 200 || $status >= 300 || ! is_array( $body ) || empty( $body['accessJwt'] ) ) {
+			$message = is_array( $body ) && ! empty( $body['message'] ) ? (string) $body['message'] : __( 'Bluesky rejected those credentials.', 'jot' );
+			return new WP_Error( 'jot_bluesky_auth_failed', $message );
+		}
+
+		$this->store_token(
+			$user_id,
+			(string) $body['accessJwt'],
+			array(
+				'refresh_token' => (string) ( $body['refreshJwt'] ?? '' ),
+				'did'           => (string) ( $body['did'] ?? '' ),
+				'username'      => (string) ( $body['handle'] ?? $handle ),
+				'service'       => self::DEFAULT_SERVICE,
+			)
+		);
+		return true;
+	}
+
+	public function fetch_recent( int $since, int $user_id ): array {
+		$token = $this->get_token( $user_id );
+		if ( ! $token ) {
+			return array();
+		}
+		$did = (string) ( $token['meta']['did'] ?? '' );
+		if ( $did === '' ) {
+			return array();
+		}
+
+		$url = add_query_arg(
+			array(
+				'actor' => $did,
+				'limit' => 50,
+			),
+			self::DEFAULT_SERVICE . '/xrpc/app.bsky.feed.getAuthorFeed'
+		);
+
+		$response = $this->authed_get( $url, $user_id, $token );
+		if ( is_wp_error( $response ) || ! is_array( $response ) || empty( $response['feed'] ) || ! is_array( $response['feed'] ) ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $response['feed'] as $entry ) {
+			if ( ! is_array( $entry ) || empty( $entry['post'] ) || ! is_array( $entry['post'] ) ) {
+				continue;
+			}
+			$post   = $entry['post'];
+			$record = is_array( $post['record'] ?? null ) ? $post['record'] : array();
+			$at_raw = (string) ( $record['createdAt'] ?? $post['indexedAt'] ?? '' );
+			$at     = $at_raw !== '' ? strtotime( $at_raw ) : false;
+			if ( $at === false || $at < $since ) {
+				continue;
+			}
+
+			$kind = 'post';
+			if ( isset( $entry['reason']['$type'] ) && $entry['reason']['$type'] === 'app.bsky.feed.defs#reasonRepost' ) {
+				$kind = 'repost';
+			} elseif ( ! empty( $record['reply'] ) ) {
+				$kind = 'reply';
+			}
+
+			$out[] = array(
+				'kind'    => $kind,
+				'text'    => (string) ( $record['text'] ?? '' ),
+				'likes'   => (int) ( $post['likeCount'] ?? 0 ),
+				'reposts' => (int) ( $post['repostCount'] ?? 0 ),
+				'replies' => (int) ( $post['replyCount'] ?? 0 ),
+				'at'      => $at,
+			);
+		}
+		return $out;
+	}
+
+	/**
+	 * Authenticated GET that refreshes the session on 401 and retries once.
+	 *
+	 * @param array{access_token:string, meta:array<string,mixed>} $token
+	 * @return array<mixed>|WP_Error
+	 */
+	private function authed_get( string $url, int $user_id, array $token ) {
+		$response = wp_remote_get(
+			$url,
+			array(
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $token['access_token'],
+					'Accept'        => 'application/json',
+					'User-Agent'    => 'Jot/' . JOT_VERSION . '; ' . home_url(),
+				),
+				'timeout' => 15,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+		$status = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( $status === 401 ) {
+			$refreshed = $this->refresh_session( $user_id, $token );
+			if ( is_wp_error( $refreshed ) ) {
+				return $refreshed;
+			}
+			return $this->authed_get( $url, $user_id, $refreshed );
+		}
+
+		if ( $status < 200 || $status >= 300 ) {
+			return new WP_Error( 'jot_bluesky_http_' . $status, (string) wp_remote_retrieve_body( $response ) );
+		}
+
+		$decoded = json_decode( (string) wp_remote_retrieve_body( $response ), true );
+		return is_array( $decoded ) ? $decoded : array();
+	}
+
+	/**
+	 * @param array{access_token:string, meta:array<string,mixed>} $token
+	 * @return array{access_token:string, meta:array<string,mixed>}|WP_Error
+	 */
+	private function refresh_session( int $user_id, array $token ) {
+		$refresh = (string) ( $token['meta']['refresh_token'] ?? '' );
+		if ( $refresh === '' ) {
+			return new WP_Error( 'jot_bluesky_no_refresh', __( 'Bluesky session expired. Reconnect with your app password.', 'jot' ) );
+		}
+
+		$response = wp_remote_post(
+			self::DEFAULT_SERVICE . '/xrpc/com.atproto.server.refreshSession',
+			array(
+				'headers' => array(
+					// refreshSession authenticates with the refresh JWT, not the access JWT.
+					'Authorization' => 'Bearer ' . $refresh,
+					'Accept'        => 'application/json',
+					'User-Agent'    => 'Jot/' . JOT_VERSION . '; ' . home_url(),
+				),
+				'timeout' => 15,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+		$status = (int) wp_remote_retrieve_response_code( $response );
+		$body   = json_decode( (string) wp_remote_retrieve_body( $response ), true );
+		if ( $status < 200 || $status >= 300 || ! is_array( $body ) || empty( $body['accessJwt'] ) ) {
+			return new WP_Error( 'jot_bluesky_refresh_failed', __( 'Bluesky refused to refresh the session. Reconnect.', 'jot' ) );
+		}
+
+		$meta = $token['meta'];
+		$meta['refresh_token'] = (string) ( $body['refreshJwt'] ?? $refresh );
+		$this->store_token( $user_id, (string) $body['accessJwt'], $meta );
+		return array(
+			'access_token' => (string) $body['accessJwt'],
+			'meta'         => $meta,
+		);
+	}
+}

--- a/includes/signals/class-jot-signals-bluesky.php
+++ b/includes/signals/class-jot-signals-bluesky.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Bluesky signal aggregator.
+ *
+ * Summarizes recent author-feed activity into a one-liner:
+ * "5 posts, 2 replies, 1 repost across 3 days; best-received: 12 likes / 4 reposts."
+ *
+ * @package Jot
+ */
+
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+class Jot_Signals_Bluesky {
+
+	/**
+	 * @param array<int, array<string, mixed>> $entries
+	 */
+	public static function aggregate( array $entries ): string {
+		if ( empty( $entries ) ) {
+			return '';
+		}
+
+		$counts    = array( 'post' => 0, 'reply' => 0, 'repost' => 0 );
+		$days      = array();
+		$best      = null;
+
+		foreach ( $entries as $e ) {
+			if ( ! is_array( $e ) ) {
+				continue;
+			}
+			$kind = (string) ( $e['kind'] ?? 'post' );
+			if ( ! isset( $counts[ $kind ] ) ) {
+				$kind = 'post';
+			}
+			$counts[ $kind ]++;
+
+			$at = (int) ( $e['at'] ?? 0 );
+			if ( $at > 0 ) {
+				$days[ gmdate( 'Y-m-d', $at ) ] = true;
+			}
+
+			$engagement = (int) ( $e['likes'] ?? 0 ) + (int) ( $e['reposts'] ?? 0 );
+			if ( $kind !== 'repost' && ( $best === null || $engagement > ( $best['score'] ?? -1 ) ) ) {
+				$best = array(
+					'score'   => $engagement,
+					'likes'   => (int) ( $e['likes'] ?? 0 ),
+					'reposts' => (int) ( $e['reposts'] ?? 0 ),
+				);
+			}
+		}
+
+		$total = array_sum( $counts );
+		if ( $total === 0 ) {
+			return '';
+		}
+
+		$segments = array();
+		if ( $counts['post'] > 0 ) {
+			/* translators: %d: number of posts */
+			$segments[] = sprintf( _n( '%d post', '%d posts', $counts['post'], 'jot' ), $counts['post'] );
+		}
+		if ( $counts['reply'] > 0 ) {
+			/* translators: %d: number of replies */
+			$segments[] = sprintf( _n( '%d reply', '%d replies', $counts['reply'], 'jot' ), $counts['reply'] );
+		}
+		if ( $counts['repost'] > 0 ) {
+			/* translators: %d: number of reposts */
+			$segments[] = sprintf( _n( '%d repost', '%d reposts', $counts['repost'], 'jot' ), $counts['repost'] );
+		}
+
+		$sentence = implode( ', ', $segments );
+
+		$day_count = count( $days );
+		if ( $day_count > 1 ) {
+			$sentence .= ' ' . sprintf(
+				/* translators: %d: number of distinct days */
+				_n( 'across %d day', 'across %d days', $day_count, 'jot' ),
+				$day_count
+			);
+		}
+
+		if ( $best !== null && $best['score'] > 0 ) {
+			$sentence .= '; ' . sprintf(
+				/* translators: 1: likes, 2: reposts */
+				__( 'best-received: %1$d likes / %2$d reposts', 'jot' ),
+				$best['likes'],
+				$best['reposts']
+			);
+		}
+
+		return $sentence . '.';
+	}
+}

--- a/jot.php
+++ b/jot.php
@@ -157,7 +157,7 @@ function jot_services(): array {
 		return $services;
 	}
 	$services = array();
-	foreach ( array( 'Jot_Service_Github', 'Jot_Service_Strava', 'Jot_Service_Spotify', 'Jot_Service_Todoist', 'Jot_Service_GoogleCalendar', 'Jot_Service_Youtube' ) as $class ) {
+	foreach ( array( 'Jot_Service_Github', 'Jot_Service_Strava', 'Jot_Service_Spotify', 'Jot_Service_Todoist', 'Jot_Service_GoogleCalendar', 'Jot_Service_Youtube', 'Jot_Service_Bluesky' ) as $class ) {
 		if ( class_exists( $class ) ) {
 			/** @var Jot_Service $instance */
 			$instance                   = new $class();


### PR DESCRIPTION
## Summary
- New \`Jot_Service_Credentials\` base for services that auth via user-supplied credentials rather than OAuth. "Connect" redirects to a credential entry form on the Connections page.
- Connections page: renders the credential form inline when \`?jot_credentials=<id>\` is set; displays authentication errors; skips credential-based services in the shared OAuth app config table.
- New \`Jot_Service_Bluesky\`: \`com.atproto.server.createSession\` with handle + app password; transparent refresh via \`refreshSession\` on 401; reads recent author-feed entries.
- New \`Jot_Signals_Bluesky\` aggregator: posts/replies/reposts split, day spread, best-received engagement.
- Registered in \`jot_services()\`.

## Design notes
- **App password, not account password.** The form help text explicitly points users at the app-passwords flow in Bluesky settings; createSession will reject account passwords for clients that set it up correctly.
- **No OAuth.** AT Protocol OAuth is real but requires DPoP + PAR + metadata endpoints. App passwords ship today with minimal surface area; we can graduate to OAuth later without changing the service interface.
- **Stored shape matches other services.** accessJwt is the "access_token"; refreshJwt lives in \`meta.refresh_token\`; \`did\` and \`username\` in meta. Downstream code doesn't care which auth flow produced the token.

## Test plan
- [ ] Go to Jot → Connections; click Connect next to Bluesky; confirm it opens the credential form (no OAuth app required).
- [ ] Submit a bad password; confirm error surfaces inline.
- [ ] Submit a valid handle + app password; confirm "Connected as <handle>" appears.
- [ ] Post something on Bluesky; refresh the widget; confirm the digest reflects activity counts.
- [ ] Force-expire: clear \`meta.access_token\` or wait out the accessJwt TTL; confirm refresh path kicks in silently on the next fetch.
- [ ] Disconnect clears user meta.
- [ ] GitHub/Strava/etc still render in the OAuth app config table; Bluesky does not.

🤖 Generated with [Craft Agent](https://craft.do)