### PR TITLE
Phase 5b: .pot + i18n CI, a11y fix, screenshot guide

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -1,0 +1,35 @@
+name: i18n
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pot-is-fresh:
+    name: languages/jot.pot is up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: wp-cli
+          coverage: none
+
+      - name: Regenerate .pot
+        run: |
+          wp i18n make-pot . languages/jot.pot \
+            --domain=jot \
+            --exclude=docs,tests,bin,.github,node_modules
+
+      - name: Fail if the committed .pot drifted
+        run: |
+          if ! git diff --quiet -- languages/jot.pot; then
+            echo "::error::languages/jot.pot is out of date. Run 'wp i18n make-pot . languages/jot.pot --domain=jot --exclude=docs,tests,bin,.github,node_modules' locally and commit the result."
+            git --no-pager diff -- languages/jot.pot | head -80
+            exit 1
+          fi

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -1,0 +1,25 @@
+# Screenshots for the WP.org listing
+
+Capture these and drop them into `assets/` at the repo root (or `.wordpress-org/` if deploying via [10up/action-wordpress-plugin-deploy](https://github.com/10up/action-wordpress-plugin-deploy)). File names must match the `screenshot-N.png` convention — the order here is the order they appear on the plugin's WP.org listing.
+
+All screenshots should be captured from a WordPress 7.0+ install with enough seeded activity to show cards (not the empty state). Render them at **1280×960** — WP.org crops to fit but preserves aspect.
+
+## Required shots
+
+1. **`screenshot-1.png` — The widget with AI suggestion cards.** Dashboard open, Jot widget expanded, three AI-generated cards with multi-source badges and tier buttons visible. This is the hero shot.
+2. **`screenshot-2.png` — The three output tiers after a click.** Widget with one card that's been converted to a "Draft created → Edit" link, plus the "Your drafts from Jot" list showing a draft with a tier pill (Spark / Outline / Full draft).
+3. **`screenshot-3.png` — Digest fallback (no AI).** Widget with GitHub / Strava digest cards and a single Quick draft button per card — proving the plugin is useful without AI.
+4. **`screenshot-4.png` — Jot → Connections admin page.** Connections table with at least one connected service + the OAuth app credentials section visible below.
+5. **`screenshot-5.png` — Jot → Settings.** Voice / style field visible.
+
+## Optional extras
+
+6. **`screenshot-6.png` — A full AI-generated draft in the Gutenberg editor.** Shows a Full draft tier output opened in the block editor with real block markup (intro, H2 sections, close paragraph).
+7. **`screenshot-7.png` — Privacy export output.** Tools → Export Personal Data run, showing the downloaded report with Jot sections populated (redact the email address).
+
+## Tips
+
+- Use the **Twenty Twenty-Six** theme on the admin side so screenshots match current WordPress.
+- Turn on `Screen Options → Disable all dashboard widgets except Jot` so the widget isn't lost between other postboxes.
+- Redact any real repo names, OAuth client IDs, or personal data before uploading.
+- Export at 2x DPI for crispness on retina displays, then downscale to 1280×960 if needed.

--- a/includes/admin/class-jot-connections-page.php
+++ b/includes/admin/class-jot-connections-page.php
@@ -171,24 +171,34 @@ class Jot_Connections_Page {
 									</form>
 								<?php else : ?>
 									<?php
-									$connect_url = wp_nonce_url(
-										add_query_arg(
-											array(
-												'page'             => self::MENU_SLUG,
-												'jot_oauth_start'  => $id,
+									if ( ! $configured ) : ?>
+										<button
+											type="button"
+											class="button"
+											disabled
+											aria-describedby="jot-connect-hint-<?php echo esc_attr( $id ); ?>"
+										>
+											<?php esc_html_e( 'Connect', 'jot' ); ?>
+										</button>
+										<span id="jot-connect-hint-<?php echo esc_attr( $id ); ?>" class="screen-reader-text">
+											<?php esc_html_e( 'An administrator must configure the OAuth app credentials first.', 'jot' ); ?>
+										</span>
+									<?php else :
+										$connect_url = wp_nonce_url(
+											add_query_arg(
+												array(
+													'page'            => self::MENU_SLUG,
+													'jot_oauth_start' => $id,
+												),
+												admin_url( 'admin.php' )
 											),
-											admin_url( 'admin.php' )
-										),
-										'jot-connect-' . $id
-									);
-									?>
-									<a
-										class="button button-primary"
-										href="<?php echo esc_url( $connect_url ); ?>"
-										<?php if ( ! $configured ) echo 'aria-disabled="true" style="pointer-events:none;opacity:.5"'; ?>
-									>
-										<?php esc_html_e( 'Connect', 'jot' ); ?>
-									</a>
+											'jot-connect-' . $id
+										);
+										?>
+										<a class="button button-primary" href="<?php echo esc_url( $connect_url ); ?>">
+											<?php esc_html_e( 'Connect', 'jot' ); ?>
+										</a>
+									<?php endif; ?>
 								<?php endif; ?>
 							</td>
 						</tr>

--- a/includes/signals/class-jot-signals-github.php
+++ b/includes/signals/class-jot-signals-github.php
@@ -67,8 +67,8 @@ class Jot_Signals_Github {
 
 		$parts = array();
 		if ( $top_stats['commits'] > 0 ) {
-			/* translators: 1: commit count, 2: day count, 3: repo name */
 			$parts[] = sprintf(
+				/* translators: 1: commit count, 2: day count, 3: repo name. */
 				_n(
 					'%1$d commit across %2$d day to %3$s',
 					'%1$d commits across %2$d days to %3$s',
@@ -82,12 +82,14 @@ class Jot_Signals_Github {
 		}
 		if ( $top_stats['prs'] > 0 ) {
 			$parts[] = sprintf(
+				/* translators: %d: pull request count. */
 				_n( '%d pull request', '%d pull requests', $top_stats['prs'], 'jot' ),
 				$top_stats['prs']
 			);
 		}
 		if ( $top_stats['stars'] > 0 ) {
 			$parts[] = sprintf(
+				/* translators: %d: starred repo count. */
 				_n( '%d starred repo', '%d starred repos', $top_stats['stars'], 'jot' ),
 				$top_stats['stars']
 			);

--- a/languages/jot.pot
+++ b/languages/jot.pot
@@ -1,0 +1,406 @@
+# Copyright (C) 2026 Anne McCarthy
+# This file is distributed under the GPL-2.0-or-later.
+msgid ""
+msgstr ""
+"Project-Id-Version: Jot 0.1.0\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/jot\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2026-04-24T19:36:25+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: jot\n"
+
+#. Plugin Name of the plugin
+#: jot.php
+#: includes/admin/class-jot-connections-page.php:38
+#: includes/admin/class-jot-connections-page.php:39
+#: includes/widget/class-jot-dashboard-widget.php:28
+msgid "Jot"
+msgstr ""
+
+#. Plugin URI of the plugin
+#: jot.php
+msgid "https://github.com/annemccarthy/jot"
+msgstr ""
+
+#. Description of the plugin
+#: jot.php
+msgid "A dashboard widget that surfaces post-idea suggestions drawn from your activity on connected services. Works without AI; becomes more useful with an AI provider connected."
+msgstr ""
+
+#. Author of the plugin
+#: jot.php
+msgid "Anne McCarthy"
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:49
+#: includes/admin/class-jot-connections-page.php:50
+msgid "Connections"
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:59
+#: includes/admin/class-jot-connections-page.php:91
+msgid "Insufficient permissions."
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:117
+msgid "Jot Connections"
+msgstr ""
+
+#. translators: %s: service id
+#: includes/admin/class-jot-connections-page.php:121
+#, php-format
+msgid "Connected: %s"
+msgstr ""
+
+#. translators: %s: service id
+#: includes/admin/class-jot-connections-page.php:126
+#, php-format
+msgid "Disconnected: %s"
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:130
+msgid "Your connections"
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:131
+msgid "Connections are per-user. Your tokens are never shared with other users on this site."
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:136
+msgid "Service"
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:137
+msgid "Status"
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:138
+msgid "Action"
+msgstr ""
+
+#. translators: %s: username on the remote service
+#: includes/admin/class-jot-connections-page.php:155
+#, php-format
+msgid "Connected as %s"
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:159
+msgid "App not configured"
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:161
+msgid "Not connected"
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:170
+msgid "Disconnect"
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:181
+#: includes/admin/class-jot-connections-page.php:199
+msgid "Connect"
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:184
+msgid "An administrator must configure the OAuth app credentials first."
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:211
+msgid "OAuth app credentials"
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:213
+msgid "Administrators only. Register an OAuth app with each service and enter its client credentials here. These credentials are shared by every user on this site — each user then connects their own account."
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:231
+msgid "Callback URL:"
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:238
+msgid "Client ID"
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:250
+msgid "Client Secret"
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:256
+msgid "(saved — leave blank to keep)"
+msgstr ""
+
+#: includes/admin/class-jot-connections-page.php:267
+msgid "Save credentials"
+msgstr ""
+
+#: includes/admin/class-jot-settings-page.php:24
+#: includes/admin/class-jot-settings-page.php:110
+msgid "Jot Settings"
+msgstr ""
+
+#: includes/admin/class-jot-settings-page.php:25
+msgid "Settings"
+msgstr ""
+
+#: includes/admin/class-jot-settings-page.php:50
+msgid "Voice"
+msgstr ""
+
+#: includes/admin/class-jot-settings-page.php:52
+msgid "Optional free-text description of your writing voice. Used as fallback when the Gutenberg content-guidelines experiment is not installed."
+msgstr ""
+
+#: includes/admin/class-jot-settings-page.php:59
+msgid "Voice / style notes"
+msgstr ""
+
+#: includes/admin/class-jot-settings-page.php:99
+msgid "e.g. Casual, frontend perf, short posts."
+msgstr ""
+
+#: includes/ai/class-jot-ai.php:38
+#: includes/ai/class-jot-ai.php:217
+msgid "No AI provider is configured."
+msgstr ""
+
+#: includes/ai/class-jot-ai.php:66
+#: includes/ai/class-jot-ai.php:238
+msgid "AI returned malformed JSON."
+msgstr ""
+
+#: includes/oauth/class-jot-service-oauth2.php:30
+msgid "You do not have permission to connect services."
+msgstr ""
+
+#: includes/oauth/class-jot-service-oauth2.php:36
+msgid "This service has not been configured yet. A site administrator must enter the OAuth app credentials first."
+msgstr ""
+
+#: includes/oauth/class-jot-service-oauth2.php:61
+msgid "You must be logged in to complete this connection."
+msgstr ""
+
+#: includes/oauth/class-jot-service-oauth2.php:68
+msgid "Missing state or authorization code."
+msgstr ""
+
+#: includes/oauth/class-jot-service-oauth2.php:73
+msgid "Invalid or expired authorization state."
+msgstr ""
+
+#: includes/oauth/class-jot-service-oauth2.php:79
+msgid "This service has not been configured."
+msgstr ""
+
+#: includes/oauth/class-jot-service-oauth2.php:103
+msgid "Token exchange failed."
+msgstr ""
+
+#: includes/oauth/class-jot-service-oauth2.php:108
+msgid "Token response was malformed."
+msgstr ""
+
+#: includes/oauth/class-jot-service-oauth2.php:155
+msgid "Not connected."
+msgstr ""
+
+#: includes/oauth/class-jot-service-oauth2.php:201
+msgid "Access token expired and no refresh token is available. Reconnect the service."
+msgstr ""
+
+#: includes/oauth/class-jot-service-oauth2.php:206
+msgid "Service app credentials missing."
+msgstr ""
+
+#: includes/oauth/class-jot-service-oauth2.php:233
+msgid "Refresh response was malformed."
+msgstr ""
+
+#. translators: %s: service label
+#: includes/rest/class-jot-rest-controller.php:170
+#, php-format
+msgid "From %s: a post idea"
+msgstr ""
+
+#: includes/services/class-jot-service-github.php:29
+msgid "GitHub"
+msgstr ""
+
+#: includes/services/class-jot-service-strava.php:52
+msgid "Strava"
+msgstr ""
+
+#. translators: 1: commit count, 2: day count, 3: repo name.
+#: includes/signals/class-jot-signals-github.php:72
+#, php-format
+msgid "%1$d commit across %2$d day to %3$s"
+msgid_plural "%1$d commits across %2$d days to %3$s"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %d: pull request count.
+#: includes/signals/class-jot-signals-github.php:86
+#, php-format
+msgid "%d pull request"
+msgid_plural "%d pull requests"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %d: starred repo count.
+#: includes/signals/class-jot-signals-github.php:93
+#, php-format
+msgid "%d starred repo"
+msgid_plural "%d starred repos"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %d: other-repo count
+#: includes/signals/class-jot-signals-github.php:102
+#, php-format
+msgid "(plus activity in %d other repo)"
+msgid_plural "(plus activity in %d other repos)"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %d: number of distinct days
+#: includes/signals/class-jot-signals-strava.php:67
+#, php-format
+msgid "across %d day."
+msgid_plural "across %d days."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: 1: activity count, 2: activity label (e.g. "runs"), 3: distance in km
+#: includes/signals/class-jot-signals-strava.php:86
+#, php-format
+msgid "%1$d %2$s totaling %3$s km"
+msgstr ""
+
+#. translators: 1: a/an article, 2: distance in km, 3: activity label (e.g. "run")
+#: includes/signals/class-jot-signals-strava.php:89
+#, php-format
+msgid "%1$s %2$s km %3$s"
+msgstr ""
+
+#. translators: 1: activity count, 2: activity label (e.g. "workouts")
+#: includes/signals/class-jot-signals-strava.php:93
+#, php-format
+msgid "%1$d %2$s"
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:56
+msgid "Jot suggestions"
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:60
+msgid "Jot settings"
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:67
+msgid "Suggestions"
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:73
+msgid "Your drafts from Jot"
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:75
+msgid "Jot drafts appear here once you create them."
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:84
+msgid "(no title)"
+msgstr ""
+
+#. translators: %s: human time diff e.g. "2 hours".
+#: includes/widget/class-jot-dashboard-widget.php:93
+#, php-format
+msgid "%s ago"
+msgstr ""
+
+#. translators: %s: human time diff e.g. "2 hours"
+#: includes/widget/class-jot-dashboard-widget.php:114
+#, php-format
+msgid "Refreshed %s ago"
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:116
+msgid "Not yet refreshed."
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:122
+msgid "Refresh"
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:138
+msgid "Connect a service and Jot will suggest post ideas from your activity."
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:141
+msgid "Connect a service"
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:152
+msgid "Nothing new in your activity yet. Try Refresh, or come back tomorrow."
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:161
+msgid "AI is unavailable."
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:162
+msgid "Showing raw activity digests below. Open the AI debug panel for details."
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:167
+msgid "Connect an AI provider for titled suggestions and full drafts."
+msgstr ""
+
+#. translators: %s: card title
+#: includes/widget/class-jot-dashboard-widget.php:201
+#, php-format
+msgid "Dismiss: %s"
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:218
+msgid "Quick spark"
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:219
+#: includes/widget/class-jot-dashboard-widget.php:289
+msgid "Outline"
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:220
+#: includes/widget/class-jot-dashboard-widget.php:290
+msgid "Full draft"
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:223
+msgid "Quick draft"
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:242
+msgid "AI debug (admin only)"
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:245
+msgid "Error:"
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:248
+msgid "Last raw response:"
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:283
+msgid "Multiple"
+msgstr ""
+
+#: includes/widget/class-jot-dashboard-widget.php:288
+msgid "Spark"
+msgstr ""


### PR DESCRIPTION
## Summary

Second slice of Phase 5. Concrete, testable pieces — manual SR testing + screenshot capture are deferred to post-merge (I can't do those).

- **\`languages/jot.pot\`** generated via \`wp i18n make-pot\`. 401 lines of translation template.
- **\`.github/workflows/i18n.yml\`** regenerates the \`.pot\` on every push/PR and **fails CI** if the committed file has drifted. Keeps the template from silently going stale.
- **Translator-comment warnings fixed** in \`Jot_Signals_Github\` so the new CI passes (moved the comments so each applies to the closest string).
- **A11y:** replaced the \"disabled link\" anti-pattern on the Connect column with a real \`<button disabled>\` plus a screen-reader-only hint explaining the disabled state. Previously \`aria-disabled=\"true\"\` + \`pointer-events:none\` let keyboard users focus and activate the link even though mouse clicks were blocked.
- **\`docs/screenshots.md\`** — five required + two optional shots for the WP.org listing at 1280×960, with guidance.

## What's still outstanding for Phase 5 (post-merge)

- Manual screen-reader pass (VoiceOver / NVDA).
- Capturing the screenshots and placing them in \`assets/\` or \`.wordpress-org/\`.

## Test plan

- [ ] Clone, run \`wp i18n make-pot . languages/jot.pot --domain=jot --exclude=docs,tests,bin,.github,node_modules\` — should produce no diff against the committed file.
- [ ] CI job \"languages/jot.pot is up to date\" passes on this PR.
- [ ] On the Connections page for a service with **no credentials configured**: the Connect control is a \`<button disabled>\`. Tab + Enter does nothing. Screen reader announces \"disabled\" plus the admin-must-configure hint.
- [ ] On the Connections page for a service **with credentials**: the Connect control is a proper \`<a class=\"button button-primary\">\` that initiates the OAuth flow.

🤖 Generated with [Craft Agent](https://craft.do)