### PR TITLE
Fix parse error from stacked service registry merges

### DIFF
--- a/jot.php
+++ b/jot.php
@@ -155,8 +155,7 @@ function jot_services(): array {
 		return $services;
 	}
 	$services = array();
-	foreach ( array( 'Jot_Service_Github', 'Jot_Service_Strava', 'Jot_Service_Todoist' ) as $class ) {
-	foreach ( array( 'Jot_Service_Github', 'Jot_Service_Strava', 'Jot_Service_Spotify' ) as $class ) {
+	foreach ( array( 'Jot_Service_Github', 'Jot_Service_Strava', 'Jot_Service_Spotify', 'Jot_Service_Todoist' ) as $class ) {
 		if ( class_exists( $class ) ) {
 			/** @var Jot_Service $instance */
 			$instance                   = new $class();


### PR DESCRIPTION
## The bug
After merging #4 (Spotify) and #5 (Todoist), \`jot.php\` fails to parse:

\`\`\`
Parse error: Unclosed '{' on line 152 in jot.php on line 260
\`\`\`

Both PRs added an identical edit to the same line — replacing the service-registry \`foreach\` header to include their new class. Git's merge stacked the two replacement lines instead of combining them:

\`\`\`php
foreach ( array( 'Jot_Service_Github', 'Jot_Service_Strava', 'Jot_Service_Todoist' ) as $class ) {
foreach ( array( 'Jot_Service_Github', 'Jot_Service_Strava', 'Jot_Service_Spotify' ) as $class ) {
    if ( class_exists( $class ) ) { ... }
}
\`\`\`

Two \`foreach (...) {\` headers in a row, one loop body, one closing brace → the outer \`{\` stays open.

## The fix
Collapse the two foreach headers into a single one that lists all four registered services (GitHub, Strava, Spotify, Todoist). Pending integration PRs (#6 #7 #9) will need rebases against main after this lands since they all touch this line too.

## Test plan
- [ ] \`php -l jot.php\` passes (verified locally).
- [ ] Activate plugin; \`jot-connections\` page renders without WSOD.
- [ ] All four services appear in the Connections list.

🤖 Generated with [Craft Agent](https://craft.do)