### PR TITLE
Fix Todoist fetch: completed/get_all requires POST

### DIFF
--- a/includes/services/class-jot-service-todoist.php
+++ b/includes/services/class-jot-service-todoist.php
@@ -72,15 +72,18 @@ class Jot_Service_Todoist extends Jot_Service_OAuth2 {
 	}
 
 	public function fetch_recent( int $since, int $user_id ): array {
-		$url = add_query_arg(
+		// Todoist Sync API endpoints — including completed/get_all — require POST,
+		// not GET. A GET silently 4xx's, which our base authed_get converts to a
+		// WP_Error and we treat as "no events" → invisible service. Use a direct
+		// POST with the form-encoded body Todoist expects.
+		$response = $this->authed_post(
+			'https://api.todoist.com/sync/v9/completed/get_all',
 			array(
 				'since' => gmdate( 'Y-m-d\TH:i:s', $since ),
 				'limit' => 200,
 			),
-			'https://api.todoist.com/sync/v9/completed/get_all'
+			$user_id
 		);
-
-		$response = $this->authed_get( $url, $user_id );
 		if ( is_wp_error( $response ) || ! is_array( $response ) || empty( $response['items'] ) || ! is_array( $response['items'] ) ) {
 			return array();
 		}
@@ -111,5 +114,42 @@ class Jot_Service_Todoist extends Jot_Service_OAuth2 {
 			);
 		}
 		return $out;
+	}
+
+	/**
+	 * Authenticated POST against the Todoist Sync API.
+	 *
+	 * @param array<string, scalar> $body
+	 * @return array<mixed>|WP_Error
+	 */
+	private function authed_post( string $url, array $body, int $user_id ) {
+		$token = $this->get_token( $user_id );
+		if ( ! $token ) {
+			return new WP_Error( 'jot_not_connected', __( 'Not connected.', 'jot' ) );
+		}
+
+		$response = wp_remote_post(
+			$url,
+			array(
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $token['access_token'],
+					'Accept'        => 'application/json',
+					'User-Agent'    => 'Jot/' . JOT_VERSION . '; ' . home_url(),
+				),
+				'body'    => $body,
+				'timeout' => 15,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+		$status = (int) wp_remote_retrieve_response_code( $response );
+		if ( $status < 200 || $status >= 300 ) {
+			return new WP_Error( 'jot_http_' . $status, (string) wp_remote_retrieve_body( $response ) );
+		}
+
+		$decoded = json_decode( (string) wp_remote_retrieve_body( $response ), true );
+		return is_array( $decoded ) ? $decoded : array();
 	}
 }


### PR DESCRIPTION
## What was happening
Todoist was connecting fine and the connection page showed "Connected as <user>", but the dashboard widget never showed Todoist activity even after refreshes. Verified via the new digest debug panel — Todoist's digest was missing entirely from \`jot_digests\`, meaning \`fetch_recent()\` was returning empty.

## Root cause
Todoist Sync API endpoints (\`/sync/v9/...\`) require **POST** with a form-encoded body. Identity lookup (\`fetch_connection_meta\`) was already correct, but \`fetch_recent\` was calling \`/completed/get_all\` via the OAuth2 base's \`authed_get\` helper — a GET. Todoist responded non-2xx, our base helper turned that into \`WP_Error\`, and \`fetch_recent\` treated it identically to "no events" → no digest → no card → invisible service.

## Fix
Add a tiny \`authed_post\` helper to the Todoist service and switch \`fetch_recent\` over. Same Bearer header, same JSON parsing, just POST with the body Todoist expects.

## Test plan
- [ ] As a user with Todoist connected and at least one task completed in the last 7 days: refresh the widget.
- [ ] Open admin "Jot debug" panel; confirm \`todoist\` appears in the digest list with a real "N tasks completed across …" line.
- [ ] Confirm at least one AI suggestion card cites \`todoist\` in \`sources\`.

## Note
This was preventable: the OAuth2 base \`authed_get\` swallows HTTP errors as if they were empty results. A future cleanup could surface them so misuse like this fails loudly. Out of scope here.

🤖 Generated with [Craft Agent](https://craft.do)