### PR TITLE
Todoist: fall back to active tasks for Free-tier accounts

### DIFF
--- a/includes/services/class-jot-service-todoist.php
+++ b/includes/services/class-jot-service-todoist.php
@@ -72,11 +72,10 @@ class Jot_Service_Todoist extends Jot_Service_OAuth2 {
 	}
 
 	public function fetch_recent( int $since, int $user_id ): array {
-		// Todoist Sync API endpoints — including completed/get_all — require POST,
-		// not GET. A GET silently 4xx's, which our base authed_get converts to a
-		// WP_Error and we treat as "no events" → invisible service. Use a direct
-		// POST with the form-encoded body Todoist expects.
-		$response = $this->authed_post(
+		// Try the completed-tasks endpoint first. This is Premium-only; for Free
+		// accounts Todoist returns an error and we fall back to the user's active
+		// tasks (a different but still useful signal — "what's on your plate").
+		$completed = $this->authed_post(
 			'https://api.todoist.com/sync/v9/completed/get_all',
 			array(
 				'since' => gmdate( 'Y-m-d\TH:i:s', $since ),
@@ -84,10 +83,18 @@ class Jot_Service_Todoist extends Jot_Service_OAuth2 {
 			),
 			$user_id
 		);
-		if ( is_wp_error( $response ) || ! is_array( $response ) || empty( $response['items'] ) || ! is_array( $response['items'] ) ) {
-			return array();
+		if ( is_array( $completed ) && ! empty( $completed['items'] ) && is_array( $completed['items'] ) ) {
+			return $this->shape_completed( $completed );
 		}
 
+		return $this->fetch_active( $user_id );
+	}
+
+	/**
+	 * @param array<string, mixed> $response
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function shape_completed( array $response ): array {
 		$projects = array();
 		if ( ! empty( $response['projects'] ) && is_array( $response['projects'] ) ) {
 			foreach ( $response['projects'] as $pid => $project ) {
@@ -98,7 +105,7 @@ class Jot_Service_Todoist extends Jot_Service_OAuth2 {
 		}
 
 		$out = array();
-		foreach ( $response['items'] as $item ) {
+		foreach ( (array) $response['items'] as $item ) {
 			if ( ! is_array( $item ) || empty( $item['completed_at'] ) ) {
 				continue;
 			}
@@ -108,9 +115,49 @@ class Jot_Service_Todoist extends Jot_Service_OAuth2 {
 			}
 			$project_id = isset( $item['project_id'] ) ? (string) $item['project_id'] : '';
 			$out[] = array(
+				'kind'    => 'completed',
 				'content' => (string) ( $item['content'] ?? '' ),
 				'project' => $projects[ $project_id ] ?? '',
 				'at'      => $completed_at,
+			);
+		}
+		return $out;
+	}
+
+	/**
+	 * Fallback for Free-tier accounts: list active tasks via REST v2. Returns
+	 * task snapshots with `kind=active` so the aggregator can switch wording.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function fetch_active( int $user_id ): array {
+		$tasks = $this->authed_get( 'https://api.todoist.com/rest/v2/tasks', $user_id );
+		if ( is_wp_error( $tasks ) || ! is_array( $tasks ) || empty( $tasks ) ) {
+			return array();
+		}
+
+		$projects_raw = $this->authed_get( 'https://api.todoist.com/rest/v2/projects', $user_id );
+		$projects     = array();
+		if ( is_array( $projects_raw ) ) {
+			foreach ( $projects_raw as $project ) {
+				if ( is_array( $project ) && ! empty( $project['id'] ) && ! empty( $project['name'] ) ) {
+					$projects[ (string) $project['id'] ] = (string) $project['name'];
+				}
+			}
+		}
+
+		$out = array();
+		foreach ( $tasks as $task ) {
+			if ( ! is_array( $task ) ) {
+				continue;
+			}
+			$created   = strtotime( (string) ( $task['created_at'] ?? '' ) );
+			$project_id = isset( $task['project_id'] ) ? (string) $task['project_id'] : '';
+			$out[] = array(
+				'kind'    => 'active',
+				'content' => (string) ( $task['content'] ?? '' ),
+				'project' => $projects[ $project_id ] ?? '',
+				'at'      => $created !== false ? $created : time(),
 			);
 		}
 		return $out;

--- a/includes/signals/class-jot-signals-todoist.php
+++ b/includes/signals/class-jot-signals-todoist.php
@@ -25,13 +25,14 @@ class Jot_Signals_Todoist {
 		$total       = 0;
 		$by_project  = array();
 		$days        = array();
-		$samples     = array();
+		$kind        = 'completed';
 
 		foreach ( $tasks as $t ) {
 			if ( ! is_array( $t ) ) {
 				continue;
 			}
 			$total++;
+			$kind    = (string) ( $t['kind'] ?? $kind );
 			$project = (string) ( $t['project'] ?? '' );
 			if ( $project === '' ) {
 				$project = __( 'Untitled project', 'jot' );
@@ -41,11 +42,6 @@ class Jot_Signals_Todoist {
 			$at = (int) ( $t['at'] ?? 0 );
 			if ( $at > 0 ) {
 				$days[ gmdate( 'Y-m-d', $at ) ] = true;
-			}
-
-			$content = trim( (string) ( $t['content'] ?? '' ) );
-			if ( $content !== '' && count( $samples ) < 3 ) {
-				$samples[] = $content;
 			}
 		}
 
@@ -62,13 +58,22 @@ class Jot_Signals_Todoist {
 			$top_parts[] = sprintf( '%s (%d)', $name, $count );
 		}
 
-		$parts   = array();
-		$parts[] = sprintf(
-			/* translators: 1: task count, 2: project count */
-			_n( '%1$d task completed across %2$d project', '%1$d tasks completed across %2$d projects', $total, 'jot' ),
-			$total,
-			$project_count
-		);
+		$parts = array();
+		if ( $kind === 'active' ) {
+			$parts[] = sprintf(
+				/* translators: 1: active task count, 2: project count */
+				_n( '%1$d active task across %2$d project', '%1$d active tasks across %2$d projects', $total, 'jot' ),
+				$total,
+				$project_count
+			);
+		} else {
+			$parts[] = sprintf(
+				/* translators: 1: completed task count, 2: project count */
+				_n( '%1$d task completed across %2$d project', '%1$d tasks completed across %2$d projects', $total, 'jot' ),
+				$total,
+				$project_count
+			);
+		}
 
 		if ( ! empty( $top_parts ) ) {
 			$parts[] = sprintf(
@@ -80,17 +85,20 @@ class Jot_Signals_Todoist {
 
 		$sentence = implode( '; ', $parts );
 
-		$day_count = count( $days );
-		if ( $day_count > 1 ) {
-			$sentence .= ' ' . sprintf(
-				/* translators: %d: number of distinct days */
-				_n( '(across %d day).', '(across %d days).', $day_count, 'jot' ),
-				$day_count
-			);
-		} else {
-			$sentence .= '.';
+		// Day spread is meaningful for "completed" (when tasks were checked off);
+		// for "active" the timestamps are creation dates, which is misleading.
+		if ( $kind === 'completed' ) {
+			$day_count = count( $days );
+			if ( $day_count > 1 ) {
+				$sentence .= ' ' . sprintf(
+					/* translators: %d: number of distinct days */
+					_n( '(across %d day).', '(across %d days).', $day_count, 'jot' ),
+					$day_count
+				);
+				return $sentence;
+			}
 		}
 
-		return $sentence;
+		return $sentence . '.';
 	}
 }


### PR DESCRIPTION
## What we found
After PR #13 (POST instead of GET), Todoist still didn't appear in the digest list. The reason: \`/sync/v9/completed/get_all\` is **Premium-only**. Free-tier accounts get an error response, our code treats that as "no events", and the service goes invisible.

## Fix
Try completed first (still works for Premium users — they get the richer "tasks completed" signal). On non-2xx or empty result, fall back to \`/rest/v2/tasks\` which lists active tasks and is available to everyone.

The signal shape changes meaning depending on which path returns:
- **completed:** "17 tasks completed across 4 projects; busiest: Inbox (9), Work (5) (across 5 days)."
- **active:** "12 active tasks across 3 projects; busiest: Inbox (5), Work (4)."

Each event now carries a \`kind\` field; \`Jot_Signals_Todoist::aggregate\` checks it and swaps the verb. The day-spread suffix is suppressed for active tasks, since their timestamps are creation dates rather than when the user did anything.

## Test plan
- [ ] Free-tier Todoist account: refresh widget; \`todoist\` appears in the digest list reading "N active tasks across …".
- [ ] AI suggestion cards: at least one card now references todoist in \`sources\`.
- [ ] Premium account (if available): completed-tasks signal still works ("N tasks completed across …").

🤖 Generated with [Craft Agent](https://craft.do)