### PR TITLE
Fix PHP leak in widget debug panel

### DIFF
--- a/includes/widget/class-jot-dashboard-widget.php
+++ b/includes/widget/class-jot-dashboard-widget.php
@@ -233,13 +233,12 @@ class Jot_Dashboard_Widget {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
-		$debug   = class_exists( 'Jot_Ai' ) ? jot_get_user_array( $user_id, Jot_Ai::DEBUG_META ) : array();
-		$digests = jot_get_user_array( $user_id, Jot_Cron::USER_DIGESTS_META );
-		if ( empty( $debug ) && empty( $digests ) ) {
+		$debug         = class_exists( 'Jot_Ai' ) ? jot_get_user_array( $user_id, Jot_Ai::DEBUG_META ) : array();
+		$digests       = jot_get_user_array( $user_id, Jot_Cron::USER_DIGESTS_META );
+		$todoist_trace = class_exists( 'Jot_Service_Todoist' ) ? jot_get_user_array( $user_id, Jot_Service_Todoist::TRACE_META ) : array();
+		if ( empty( $debug ) && empty( $digests ) && empty( $todoist_trace ) ) {
 			return;
 		}
-		?>
-		$todoist_trace = class_exists( 'Jot_Service_Todoist' ) ? jot_get_user_array( $user_id, Jot_Service_Todoist::TRACE_META ) : array();
 		?>
 		<details class="jot-widget__debug">
 			<summary><?php esc_html_e( 'Jot debug (admin only)', 'jot' ); ?></summary>


### PR DESCRIPTION
Follow-up to #15.

The trace-panel patch put \`\$todoist_trace = …;\` between two \`?>\` markers, so it rendered as literal source text in the admin debug section. The fix landed on the branch after #15 was already merged — so main still has the leak.

This PR cherry-picks just that one-line fix onto main.

## Test plan
- [ ] Refresh dashboard widget; "Jot debug" panel no longer shows PHP source as plain text.
- [ ] Trace section ("Todoist fetch attempts:") renders correctly.

🤖 Generated with [Craft Agent](https://craft.do)