### PR TITLE
Recognize Todoist's "items" list envelope

### DIFF
--- a/includes/services/class-jot-service-todoist.php
+++ b/includes/services/class-jot-service-todoist.php
@@ -192,7 +192,10 @@ class Jot_Service_Todoist extends Jot_Service_OAuth2 {
 	}
 
 	/**
-	 * Accept either a flat array or a paginated `{ "results": [...] }` envelope.
+	 * Accept a flat array or any of Todoist's v1 list envelopes. Different v1
+	 * endpoints picked different keys: /projects returns `{"results":[...]}`,
+	 * /tasks/completed returns `{"items":[...]}`. If neither is present, treat
+	 * the response itself as the list.
 	 *
 	 * @param mixed $response
 	 * @return array<int, mixed>
@@ -201,8 +204,10 @@ class Jot_Service_Todoist extends Jot_Service_OAuth2 {
 		if ( ! is_array( $response ) ) {
 			return array();
 		}
-		if ( isset( $response['results'] ) && is_array( $response['results'] ) ) {
-			return $response['results'];
+		foreach ( array( 'results', 'items' ) as $key ) {
+			if ( isset( $response[ $key ] ) && is_array( $response[ $key ] ) ) {
+				return $response[ $key ];
+			}
 		}
 		return $response;
 	}


### PR DESCRIPTION
## Trace from #18 (after merge)
\`\`\`
GET 200 https://api.todoist.com/api/v1/tasks/completed?since=...
{"items":[{"completed_at":"2026-04-25T16:31:23..."}, ...]}

GET 200 https://api.todoist.com/api/v1/projects
{"results":[{"id":"...", "name":"Architecture", ...}, ...]}
\`\`\`

Two 200s — but the digest list still showed only github + strava.

## Cause
Todoist's v1 endpoints don't agree on a single envelope key. \`/projects\` uses \`results\`, \`/tasks/completed\` uses \`items\`. The \`unwrap_list()\` helper from #17/#18 only knew about \`results\`, so for completed-tasks it fell through to the "treat the whole response as the list" branch — \`shape_tasks()\` then iterated a one-element list (the wrapping array under \`items\`), every "task" failed the \`completed_at\` guard, and the function returned an empty array.

Net effect: trace says 200, data is right there, digest is silently empty.

## Fix
Teach \`unwrap_list()\` to recognize either key. Tiny diff.

## Test plan
- [ ] Refresh widget. Trace still shows two 200s.
- [ ] "Digests sent to AI:" now reads \`github, strava, todoist\`.
- [ ] AI cards include at least one with \`todoist\` in \`sources\`.

🤖 Generated with [Craft Agent](https://craft.do)