### PR TITLE
Add Connect button feedback on the connections screen

### DIFF
--- a/assets/jot-connect-ux.css
+++ b/assets/jot-connect-ux.css
@@ -1,0 +1,28 @@
+/**
+ * Jot — Connect button feedback styles.
+ */
+@keyframes jot-row-flash {
+	0%   { background-color: #e7f4ec; }
+	100% { background-color: transparent; }
+}
+
+.jot-row-just-connected td {
+	animation: jot-row-flash 2.4s ease-out;
+}
+
+a.button[data-jot-connecting="1"]::after {
+	content: "";
+	display: inline-block;
+	margin-left: 8px;
+	width: 12px;
+	height: 12px;
+	border: 2px solid currentColor;
+	border-top-color: transparent;
+	border-radius: 50%;
+	animation: jot-spin 0.8s linear infinite;
+	vertical-align: -2px;
+}
+
+@keyframes jot-spin {
+	to { transform: rotate(360deg); }
+}

--- a/assets/jot-connect-ux.js
+++ b/assets/jot-connect-ux.js
@@ -1,0 +1,62 @@
+/**
+ * Jot — Connect button feedback.
+ *
+ * Server-side OAuth round trips can complete in well under a second
+ * when the provider auto-approves a previously authorized app. The
+ * resulting visual change can be so brief that it looks like nothing
+ * happened. This script gives the Connect button an immediate
+ * "Connecting…" state, and on return surfaces a brief highlight on
+ * the row that just connected.
+ */
+( function () {
+	'use strict';
+
+	function markConnecting( link ) {
+		if ( link.dataset.jotConnecting === '1' ) {
+			return;
+		}
+		link.dataset.jotConnecting = '1';
+		link.setAttribute( 'aria-busy', 'true' );
+		link.style.pointerEvents = 'none';
+		link.style.opacity = '0.7';
+		link.textContent = link.dataset.connectingLabel || 'Connecting…';
+	}
+
+	function bindConnectButtons() {
+		var links = document.querySelectorAll( 'a.button[href*="jot_oauth_start="]' );
+		Array.prototype.forEach.call( links, function ( link ) {
+			link.addEventListener( 'click', function () {
+				markConnecting( link );
+			} );
+		} );
+	}
+
+	function flashConnectedRow() {
+		var url = new URL( window.location.href );
+		var connected = url.searchParams.get( 'connected' );
+		if ( ! connected ) {
+			return;
+		}
+		var row = document.querySelector(
+			'tr[data-jot-service="' + connected.replace( /"/g, '' ) + '"]'
+		);
+		if ( ! row ) {
+			return;
+		}
+		row.classList.add( 'jot-row-just-connected' );
+		row.scrollIntoView( { behavior: 'smooth', block: 'center' } );
+		window.setTimeout( function () {
+			row.classList.remove( 'jot-row-just-connected' );
+		}, 2400 );
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', function () {
+			bindConnectButtons();
+			flashConnectedRow();
+		} );
+	} else {
+		bindConnectButtons();
+		flashConnectedRow();
+	}
+} )();

--- a/includes/admin/class-jot-connections-page.php
+++ b/includes/admin/class-jot-connections-page.php
@@ -240,7 +240,7 @@ class Jot_Connections_Page {
 						$configured     = $is_credentials || ( ! empty( $apps[ $id ]['client_id'] ) && ! empty( $apps[ $id ]['client_secret'] ) );
 						$connected      = ! empty( $status['connected'] );
 						?>
-						<tr>
+						<tr data-jot-service="<?php echo esc_attr( $id ); ?>">
 							<td><strong><?php echo esc_html( $service->label() ); ?></strong></td>
 							<td>
 								<?php if ( $connected ) : ?>
@@ -280,6 +280,7 @@ class Jot_Connections_Page {
 									<a
 										class="button button-primary"
 										href="<?php echo esc_url( $connect_url ); ?>"
+										data-connecting-label="<?php esc_attr_e( 'Connecting…', 'jot' ); ?>"
 										<?php if ( ! $configured ) echo 'aria-disabled="true" style="pointer-events:none;opacity:.5"'; ?>
 									>
 										<?php esc_html_e( 'Connect', 'jot' ); ?>

--- a/jot.php
+++ b/jot.php
@@ -258,3 +258,26 @@ function jot_enqueue_widget_assets( string $hook ): void {
 		true
 	);
 }
+
+add_action( 'admin_enqueue_scripts', 'jot_enqueue_connect_ux_assets' );
+function jot_enqueue_connect_ux_assets( string $hook ): void {
+	$page = isset( $_GET['page'] ) ? sanitize_key( (string) wp_unslash( $_GET['page'] ) ) : '';
+	if ( $page !== Jot_Connections_Page::MENU_SLUG ) {
+		return;
+	}
+
+	wp_enqueue_style(
+		'jot-connect-ux',
+		JOT_PLUGIN_URL . 'assets/jot-connect-ux.css',
+		array(),
+		JOT_VERSION
+	);
+
+	wp_enqueue_script(
+		'jot-connect-ux',
+		JOT_PLUGIN_URL . 'assets/jot-connect-ux.js',
+		array(),
+		JOT_VERSION,
+		true
+	);
+}


### PR DESCRIPTION
## Summary

When an OAuth provider auto-approves a previously authorized app, the full connect → authorize → callback → redirect chain can complete in under a second. The connections page rerenders, but the visible state can change so briefly that it looks like the click did nothing — only a manual refresh makes the new "Connected" state register for the user.

This PR adds two small UX affordances on the connections screen:

- **Immediate "Connecting…" spinner** on the Connect button the moment it's clicked, so feedback fires before the redirect chain starts.
- **Row highlight + scroll into view** when the page renders with \`?connected=<service>\`, so success is unmistakable when the redirect chain lands back on the connections page.

The OAuth flow itself is unchanged — this is purely client-side polish.

## Implementation

- New \`assets/jot-connect-ux.js\` and \`assets/jot-connect-ux.css\`, enqueued only on the Jot connections screen.
- \`<tr>\` rows now carry \`data-jot-service="<id>"\` so the success flash can target the right row.
- Connect anchor carries a translatable \`data-connecting-label\` so the spinner text localizes.

## Test plan

- [ ] Connect a service for the first time → consent screen appears → return → row flashes briefly with "Connected as …".
- [ ] Disconnect, then connect again (provider auto-approves) → button shows "Connecting…" with spinner immediately, then row flashes on return.
- [ ] Click "Connect" on a service whose OAuth app isn't configured (button is disabled) → no spinner, no nav.
- [ ] No regressions on the existing notices, credential editor, or per-service connect URL.