### PR TITLE
Remove "Full draft" generation tier

### DIFF
--- a/assets/jot-widget.js
+++ b/assets/jot-widget.js
@@ -80,7 +80,7 @@
 		const originalLabel = button.textContent;
 		const siblings = card.querySelectorAll( 'button' );
 		siblings.forEach( function ( b ) { b.disabled = true; } );
-		button.textContent = tier === 'full' ? __( 'Drafting…' ) : __( 'Creating…' );
+		button.textContent = __( 'Creating…' );
 
 		const body = { angle_key: angleKey };
 		if ( tier ) { body.tier = tier; }

--- a/includes/ai/class-jot-ai.php
+++ b/includes/ai/class-jot-ai.php
@@ -268,34 +268,6 @@ class Jot_Ai {
 			return rtrim( $out );
 		}
 
-		if ( $tier === Jot_Prompts::TIER_FULL ) {
-			$out = '';
-			$intro = trim( (string) ( $data['intro'] ?? '' ) );
-			if ( $intro !== '' ) {
-				foreach ( preg_split( "/\n{2,}/", $intro ) ?: array() as $para ) {
-					$out .= "<!-- wp:paragraph -->\n<p>" . wp_kses_post( $para ) . "</p>\n<!-- /wp:paragraph -->\n\n";
-				}
-			}
-			foreach ( (array) ( $data['sections'] ?? array() ) as $section ) {
-				$heading = wp_kses_post( (string) ( $section['heading'] ?? '' ) );
-				$body    = trim( (string) ( $section['body'] ?? '' ) );
-				$out    .= "<!-- wp:heading {\"level\":2} -->\n<h2>" . $heading . "</h2>\n<!-- /wp:heading -->\n\n";
-				foreach ( preg_split( "/\n{2,}/", $body ) ?: array() as $para ) {
-					if ( $para === '' ) {
-						continue;
-					}
-					$out .= "<!-- wp:paragraph -->\n<p>" . wp_kses_post( $para ) . "</p>\n<!-- /wp:paragraph -->\n\n";
-				}
-			}
-			$close = trim( (string) ( $data['close'] ?? '' ) );
-			if ( $close !== '' ) {
-				foreach ( preg_split( "/\n{2,}/", $close ) ?: array() as $para ) {
-					$out .= "<!-- wp:paragraph -->\n<p>" . wp_kses_post( $para ) . "</p>\n<!-- /wp:paragraph -->\n\n";
-				}
-			}
-			return rtrim( $out );
-		}
-
 		return '';
 	}
 }

--- a/includes/ai/class-jot-prompts.php
+++ b/includes/ai/class-jot-prompts.php
@@ -17,7 +17,6 @@ class Jot_Prompts {
 
 	public const TIER_SPARK   = 'spark';
 	public const TIER_OUTLINE = 'outline';
-	public const TIER_FULL    = 'full';
 
 	/**
 	 * Prompt for generating 3–5 post-angle suggestion cards.
@@ -107,27 +106,6 @@ Return ONLY a JSON object:
 }
 OUTLINE,
 
-			self::TIER_FULL => $shared . <<<'FULL'
-Write a full first-draft blog post for this angle. Structure it as:
-- Short intro (1 short paragraph)
-- 3 to 5 body sections, each with a heading and 1 to 3 paragraphs
-- Short close (1 short paragraph)
-
-Match the writer's voice. Keep it honest and specific — draw on the source activity. Do not fabricate details.
-
-Return ONLY a JSON object:
-{
-  "title": "...",
-  "intro": "...",
-  "sections": [
-    { "heading": "...", "body": "..." },
-    ...
-  ],
-  "close": "..."
-}
-Each body string should be plain prose; paragraphs separated by two newlines. No markdown.
-FULL,
-
 			default => $shared,
 		};
 	}
@@ -164,26 +142,6 @@ FULL,
 					),
 				),
 				'required'   => array( 'title', 'sections' ),
-			),
-			self::TIER_FULL => array(
-				'type'       => 'object',
-				'properties' => array(
-					'title'    => array( 'type' => 'string' ),
-					'intro'    => array( 'type' => 'string' ),
-					'sections' => array(
-						'type'  => 'array',
-						'items' => array(
-							'type'       => 'object',
-							'properties' => array(
-								'heading' => array( 'type' => 'string' ),
-								'body'    => array( 'type' => 'string' ),
-							),
-							'required'   => array( 'heading', 'body' ),
-						),
-					),
-					'close'    => array( 'type' => 'string' ),
-				),
-				'required'   => array( 'title', 'intro', 'sections', 'close' ),
 			),
 			default => array( 'type' => 'object' ),
 		};

--- a/includes/rest/class-jot-rest-controller.php
+++ b/includes/rest/class-jot-rest-controller.php
@@ -151,7 +151,7 @@ class Jot_Rest_Controller {
 		$body  = '';
 		$used_tier = 'quick_draft';
 
-		if ( in_array( $tier, array( Jot_Prompts::TIER_SPARK, Jot_Prompts::TIER_OUTLINE, Jot_Prompts::TIER_FULL ), true )
+		if ( in_array( $tier, array( Jot_Prompts::TIER_SPARK, Jot_Prompts::TIER_OUTLINE ), true )
 			&& class_exists( 'Jot_Ai' ) && Jot_Ai::is_available() ) {
 
 			$settings = get_option( 'jot_settings', array() );

--- a/includes/widget/class-jot-dashboard-widget.php
+++ b/includes/widget/class-jot-dashboard-widget.php
@@ -164,7 +164,7 @@ class Jot_Dashboard_Widget {
 			<?php
 		} elseif ( ! $ai_available ) {
 			?>
-			<p class="jot-widget__muted"><?php esc_html_e( 'Connect an AI provider for titled suggestions and full drafts.', 'jot' ); ?></p>
+			<p class="jot-widget__muted"><?php esc_html_e( 'Connect an AI provider for titled suggestions and outlines.', 'jot' ); ?></p>
 			<?php
 		}
 
@@ -216,8 +216,7 @@ class Jot_Dashboard_Widget {
 			<div class="jot-widget__card-actions">
 				<?php if ( $tier_buttons ) : ?>
 					<button type="button" class="button jot-widget__tier" data-tier="spark"><?php esc_html_e( 'Quick spark', 'jot' ); ?></button>
-					<button type="button" class="button jot-widget__tier" data-tier="outline"><?php esc_html_e( 'Outline', 'jot' ); ?></button>
-					<button type="button" class="button button-primary jot-widget__tier" data-tier="full"><?php esc_html_e( 'Full draft', 'jot' ); ?></button>
+					<button type="button" class="button button-primary jot-widget__tier" data-tier="outline"><?php esc_html_e( 'Outline', 'jot' ); ?></button>
 				<?php else : ?>
 					<button type="button" class="button button-primary jot-widget__quick-draft">
 						<?php esc_html_e( 'Quick draft', 'jot' ); ?>
@@ -333,7 +332,6 @@ class Jot_Dashboard_Widget {
 		return match ( $tier ) {
 			'spark'   => __( 'Spark', 'jot' ),
 			'outline' => __( 'Outline', 'jot' ),
-			'full'    => __( 'Full draft', 'jot' ),
 			default   => $tier,
 		};
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ A dashboard widget that surfaces post-idea suggestions drawn from your activity 
 
 == Description ==
 
-Jot adds a dashboard widget that suggests blog post angles based on your activity on services like GitHub, Mastodon, Bluesky, and Strava. Without AI it shows aggregated digests; with an AI provider connected through the WordPress 7.0 Connectors API it produces titled suggestion cards with three output tiers: quick spark, outline, or full draft.
+Jot adds a dashboard widget that suggests blog post angles based on your activity on services like GitHub, Mastodon, Bluesky, and Strava. Without AI it shows aggregated digests; with an AI provider connected through the WordPress 7.0 Connectors API it produces titled suggestion cards with two scaffold options: quick spark or outline. Jot deliberately does not generate finished posts — the writer fills in the page.
 
 Jot never auto-publishes. Every draft is a user-initiated click.
 


### PR DESCRIPTION
Closes #21.

## Summary
- Removes the **Full draft** button from the dashboard widget; **Outline** becomes the primary action.
- Drops `TIER_FULL` from `Jot_Prompts` (constant, prompt branch, JSON schema) and from `Jot_Ai::blockify()`.
- REST `/draft` endpoint no longer accepts `tier=full` — falls through to the quick-draft path.
- Updates the muted "no AI" hint and `readme.txt` description to match the new two-scaffold model.

## Why
Per #21, full-draft generation conflicts with Jot's "no AI slop" stance. Jot scaffolds ideas to address the blank-page problem; it should not produce finished posts.

## Test plan
- [ ] Load the dashboard widget with an AI provider connected — only **Quick spark** and **Outline** buttons appear; **Outline** is primary.
- [ ] Click **Outline** — draft is created with H2 sections.
- [ ] POST `/wp-json/jot/v1/draft` with `tier=full` — server falls back to the plain digest body (does not invoke AI tier path).
- [ ] `php -l` passes on all touched PHP files.