### PR TITLE
Remove the Jot debug panel

### DIFF
--- a/assets/jot-widget.css
+++ b/assets/jot-widget.css
@@ -239,29 +239,6 @@
 	align-items: center;
 }
 
-.jot-widget__debug {
-	margin-top: 16px;
-	padding: 8px;
-	background: #fafafa;
-	border-radius: 3px;
-	font-size: 12px;
-}
-
-.jot-widget__debug summary {
-	cursor: pointer;
-	color: #50575e;
-}
-
-.jot-widget__debug-pre {
-	white-space: pre-wrap;
-	max-height: 200px;
-	overflow: auto;
-	font-size: 11px;
-	background: #f6f7f7;
-	padding: 8px;
-	margin-top: 6px;
-}
-
 .jot-status {
 	display: inline-block;
 	padding: 2px 8px;

--- a/includes/ai/class-jot-ai.php
+++ b/includes/ai/class-jot-ai.php
@@ -31,8 +31,6 @@ class Jot_Ai {
 	 * @param array<int, string>                                                            $recent_titles
 	 * @return array<int, array{title:string,rationale:string,angle_key:string,service:string,label:string,digest:string}>|WP_Error
 	 */
-	public const DEBUG_META = 'jot_ai_last_debug';
-
 	public static function generate_cards( array $digests, array $recent_titles, string $voice_hint ) {
 		if ( ! self::is_available() ) {
 			return new WP_Error( 'jot_ai_unavailable', __( 'No AI provider is configured.', 'jot' ) );
@@ -47,15 +45,6 @@ class Jot_Ai {
 		// capability that as_json_response() requires, causing "No models found"
 		// errors. We ask for JSON in the prompt and parse it ourselves.
 		$raw = wp_ai_client_prompt( $prompt )->generate_text();
-
-		self::record_debug(
-			array(
-				'at'    => time(),
-				'stage' => 'cards',
-				'error' => is_wp_error( $raw ) ? $raw->get_error_message() : '',
-				'raw'   => is_wp_error( $raw ) ? '' : substr( (string) $raw, 0, 2000 ),
-			)
-		);
 
 		if ( is_wp_error( $raw ) ) {
 			return $raw;
@@ -186,27 +175,6 @@ class Jot_Ai {
 	}
 
 	/**
-	 * @param array<string, mixed> $debug
-	 */
-	private static function record_debug( array $debug ): void {
-		$user_id = get_current_user_id();
-		if ( $user_id === 0 ) {
-			// Cron runs with no user. Stash on the first user that has connections
-			// — debug is admin-only, so this is fine.
-			global $wpdb;
-			$row = $wpdb->get_row(
-				"SELECT user_id FROM {$wpdb->usermeta} WHERE meta_key LIKE 'jot_oauth_tokens_%' LIMIT 1",
-				ARRAY_A
-			);
-			$user_id = isset( $row['user_id'] ) ? (int) $row['user_id'] : 0;
-		}
-		if ( $user_id === 0 ) {
-			return;
-		}
-		update_user_meta( $user_id, self::DEBUG_META, $debug );
-	}
-
-	/**
 	 * Generate the tier-specific output for one card.
 	 *
 	 * @param array{title:string,rationale:string,digest:string,service:string,label:string} $card
@@ -219,15 +187,6 @@ class Jot_Ai {
 
 		$prompt = Jot_Prompts::tier( $tier, $card, $voice_hint );
 		$raw    = wp_ai_client_prompt( $prompt )->generate_text();
-
-		self::record_debug(
-			array(
-				'at'    => time(),
-				'stage' => 'tier:' . $tier,
-				'error' => is_wp_error( $raw ) ? $raw->get_error_message() : '',
-				'raw'   => is_wp_error( $raw ) ? '' : substr( (string) $raw, 0, 2000 ),
-			)
-		);
 
 		if ( is_wp_error( $raw ) ) {
 			return $raw;

--- a/includes/services/class-jot-service-todoist.php
+++ b/includes/services/class-jot-service-todoist.php
@@ -23,8 +23,6 @@ defined( 'ABSPATH' ) || exit;
 
 class Jot_Service_Todoist extends Jot_Service_OAuth2 {
 
-	public const TRACE_META = 'jot_todoist_trace';
-
 	public function __construct() {
 		// Canonical hosts per the v1 docs; the bare todoist.com aliases redirect,
 		// but the redirect-on-POST behavior on the token exchange has been flaky.
@@ -74,8 +72,6 @@ class Jot_Service_Todoist extends Jot_Service_OAuth2 {
 	}
 
 	public function fetch_recent( int $since, int $user_id ): array {
-		$trace = array( 'at' => time(), 'attempts' => array() );
-
 		// Try completed first (Premium accounts get a richer signal). Path is
 		// /api/v1/tasks/completed with `since` as ISO 8601. Falls through to
 		// the active-tasks list on any non-2xx or empty result.
@@ -86,31 +82,26 @@ class Jot_Service_Todoist extends Jot_Service_OAuth2 {
 			),
 			'https://api.todoist.com/api/v1/tasks/completed'
 		);
-		$completed_raw = $this->traced_get( $completed_url, $user_id, $trace );
+		$completed_raw = $this->fetch_url( $completed_url, $user_id );
 		$completed     = is_wp_error( $completed_raw ) ? array() : self::unwrap_list( $completed_raw );
 
 		if ( ! empty( $completed ) ) {
-			$out = $this->shape_tasks( $completed, $this->fetch_projects( $user_id, $trace ), 'completed' );
-			update_user_meta( $user_id, self::TRACE_META, $trace );
-			return $out;
+			return $this->shape_tasks( $completed, $this->fetch_projects( $user_id ), 'completed' );
 		}
 
-		$active_raw = $this->traced_get( 'https://api.todoist.com/api/v1/tasks', $user_id, $trace );
+		$active_raw = $this->fetch_url( 'https://api.todoist.com/api/v1/tasks', $user_id );
 		$active     = is_wp_error( $active_raw ) ? array() : self::unwrap_list( $active_raw );
 		if ( empty( $active ) ) {
-			update_user_meta( $user_id, self::TRACE_META, $trace );
 			return array();
 		}
-		$out = $this->shape_tasks( $active, $this->fetch_projects( $user_id, $trace ), 'active' );
-		update_user_meta( $user_id, self::TRACE_META, $trace );
-		return $out;
+		return $this->shape_tasks( $active, $this->fetch_projects( $user_id ), 'active' );
 	}
 
 	/**
 	 * @return array<string, string> project_id => name
 	 */
-	private function fetch_projects( int $user_id, array &$trace ): array {
-		$raw      = $this->traced_get( 'https://api.todoist.com/api/v1/projects', $user_id, $trace );
+	private function fetch_projects( int $user_id ): array {
+		$raw      = $this->fetch_url( 'https://api.todoist.com/api/v1/projects', $user_id );
 		$projects = array();
 		if ( ! is_wp_error( $raw ) ) {
 			foreach ( self::unwrap_list( $raw ) as $project ) {
@@ -152,14 +143,13 @@ class Jot_Service_Todoist extends Jot_Service_OAuth2 {
 	}
 
 	/**
-	 * GET wrapper that records the response into the trace ref.
+	 * Authenticated GET against a Todoist v1 endpoint.
 	 *
 	 * @return array<mixed>|WP_Error
 	 */
-	private function traced_get( string $url, int $user_id, array &$trace ) {
+	private function fetch_url( string $url, int $user_id ) {
 		$token = $this->get_token( $user_id );
 		if ( ! $token ) {
-			$this->add_trace( $trace, 'GET', $url, 0, 'not_connected', '' );
 			return new WP_Error( 'jot_not_connected', __( 'Not connected.', 'jot' ) );
 		}
 
@@ -176,12 +166,9 @@ class Jot_Service_Todoist extends Jot_Service_OAuth2 {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			$this->add_trace( $trace, 'GET', $url, 0, $response->get_error_message(), '' );
 			return $response;
 		}
 		$status = (int) wp_remote_retrieve_response_code( $response );
-		$body_excerpt = substr( (string) wp_remote_retrieve_body( $response ), 0, 500 );
-		$this->add_trace( $trace, 'GET', $url, $status, '', $body_excerpt );
 
 		if ( $status < 200 || $status >= 300 ) {
 			return new WP_Error( 'jot_http_' . $status, (string) wp_remote_retrieve_body( $response ) );
@@ -212,16 +199,4 @@ class Jot_Service_Todoist extends Jot_Service_OAuth2 {
 		return $response;
 	}
 
-	private function add_trace( ?array &$trace, string $method, string $url, int $status, string $error, string $body_excerpt ): void {
-		if ( $trace === null ) {
-			return;
-		}
-		$trace['attempts'][] = array(
-			'method' => $method,
-			'url'    => $url,
-			'status' => $status,
-			'error'  => $error,
-			'body'   => $body_excerpt,
-		);
-	}
 }

--- a/includes/widget/class-jot-dashboard-widget.php
+++ b/includes/widget/class-jot-dashboard-widget.php
@@ -100,8 +100,6 @@ class Jot_Dashboard_Widget {
 				<?php endif; ?>
 			</section>
 
-			<?php $this->render_debug_panel( $user_id ); ?>
-
 			<footer class="jot-widget__footer">
 				<span class="jot-widget__muted jot-widget__refreshed"
 					<?php if ( $last_refresh > 0 ) : ?>
@@ -225,78 +223,6 @@ class Jot_Dashboard_Widget {
 			</div>
 			<p class="jot-widget__card-error" role="alert" hidden></p>
 		</li>
-		<?php
-	}
-
-	private function render_debug_panel( int $user_id ): void {
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return;
-		}
-		$debug         = class_exists( 'Jot_Ai' ) ? jot_get_user_array( $user_id, Jot_Ai::DEBUG_META ) : array();
-		$digests       = jot_get_user_array( $user_id, Jot_Cron::USER_DIGESTS_META );
-		$todoist_trace = class_exists( 'Jot_Service_Todoist' ) ? jot_get_user_array( $user_id, Jot_Service_Todoist::TRACE_META ) : array();
-		if ( empty( $debug ) && empty( $digests ) && empty( $todoist_trace ) ) {
-			return;
-		}
-		?>
-		<details class="jot-widget__debug">
-			<summary><?php esc_html_e( 'Jot debug (admin only)', 'jot' ); ?></summary>
-
-			<?php if ( ! empty( $todoist_trace['attempts'] ) ) : ?>
-				<p class="jot-widget__muted"><strong><?php esc_html_e( 'Todoist fetch attempts:', 'jot' ); ?></strong></p>
-				<ul class="jot-widget__debug-digests">
-					<?php foreach ( (array) $todoist_trace['attempts'] as $attempt ) : ?>
-						<li>
-							<code><?php echo esc_html( (string) ( $attempt['method'] ?? '' ) . ' ' . (string) ( $attempt['status'] ?? '' ) ); ?></code>
-							<?php echo esc_html( (string) ( $attempt['url'] ?? '' ) ); ?>
-							<?php if ( ! empty( $attempt['error'] ) ) : ?>
-								— <em><?php echo esc_html( (string) $attempt['error'] ); ?></em>
-							<?php endif; ?>
-							<?php if ( ! empty( $attempt['body'] ) ) : ?>
-								<pre class="jot-widget__debug-pre"><?php echo esc_html( (string) $attempt['body'] ); ?></pre>
-							<?php endif; ?>
-						</li>
-					<?php endforeach; ?>
-				</ul>
-			<?php endif; ?>
-
-			<?php if ( ! empty( $digests ) ) : ?>
-				<p class="jot-widget__muted">
-					<strong><?php esc_html_e( 'Digests sent to AI:', 'jot' ); ?></strong>
-					<?php
-					$ids = array_map( static fn ( array $d ): string => (string) ( $d['service'] ?? '' ), $digests );
-					echo esc_html( implode( ', ', array_filter( $ids ) ) );
-					?>
-				</p>
-				<ul class="jot-widget__debug-digests">
-					<?php foreach ( $digests as $digest ) : ?>
-						<li>
-							<code><?php echo esc_html( (string) ( $digest['service'] ?? '?' ) ); ?></code>
-							— <?php echo esc_html( (string) ( $digest['digest'] ?? '' ) ); ?>
-						</li>
-					<?php endforeach; ?>
-				</ul>
-			<?php else : ?>
-				<p class="jot-widget__muted">
-					<strong><?php esc_html_e( 'No digests stored.', 'jot' ); ?></strong>
-					<?php esc_html_e( 'Either no services are connected, or every connected service returned zero events for the current window.', 'jot' ); ?>
-				</p>
-			<?php endif; ?>
-
-			<?php if ( ! empty( $debug ) ) : ?>
-				<p class="jot-widget__muted">
-					<?php if ( ! empty( $debug['error'] ) ) : ?>
-						<strong><?php esc_html_e( 'AI error:', 'jot' ); ?></strong>
-						<?php echo esc_html( (string) $debug['error'] ); ?>
-					<?php else : ?>
-						<strong><?php esc_html_e( 'Last raw AI response:', 'jot' ); ?></strong>
-					<?php endif; ?>
-				</p>
-				<?php if ( ! empty( $debug['raw'] ) ) : ?>
-					<pre class="jot-widget__debug-pre"><?php echo esc_html( (string) $debug['raw'] ); ?></pre>
-				<?php endif; ?>
-			<?php endif; ?>
-		</details>
 		<?php
 	}
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -26,6 +26,7 @@ $user_meta_keys = array(
 	'jot_last_refresh',
 	'jot_last_ai_error',
 	'jot_ai_last_debug',
+	'jot_todoist_trace',
 	'jot_user_acted_on',
 	'jot_user_dismissed',
 	'jot_oauth_tokens_github',


### PR DESCRIPTION
## Summary
- Removes the admin-only **Jot debug** `<details>` panel from the dashboard widget.
- Drops `Jot_Ai::DEBUG_META` + `record_debug()` and the call sites in `generate_cards()` / `generate_tier()`.
- Drops Todoist `TRACE_META` + `add_trace()`; renames `traced_get()` → `fetch_url()` and removes the trace plumbing through `fetch_recent()` / `fetch_projects()`.
- Drops the `.jot-widget__debug*` CSS rules.
- Adds `jot_todoist_trace` to `uninstall.php` so legacy installs get their orphaned user_meta cleaned up. (`jot_ai_last_debug` was already in the list.)

## Why
The debug panel was useful while we were stabilizing AI + Todoist plumbing. Now that those paths are stable it's just dead surface area on every admin's dashboard. If we need that visibility again, git history has it.

## Test plan
- [ ] Load the dashboard widget as an admin — no debug `<details>` element renders.
- [ ] Refresh activity / generate a draft — works without errors (no missing `record_debug` etc.).
- [ ] Connect Todoist and run a refresh — completed/active fetch still works (now via `fetch_url()`).
- [ ] Uninstall the plugin on an install that had `jot_ai_last_debug` or `jot_todoist_trace` meta — both are deleted.