### PR TITLE
Add hover tooltip to dismiss × on suggestion cards

### DIFF
--- a/includes/widget/class-jot-dashboard-widget.php
+++ b/includes/widget/class-jot-dashboard-widget.php
@@ -199,6 +199,7 @@ class Jot_Dashboard_Widget {
 				type="button"
 				class="jot-widget__dismiss"
 				aria-label="<?php echo esc_attr( sprintf( /* translators: %s: card title */ __( 'Dismiss: %s', 'jot' ), $title !== '' ? $title : $badge_aria ) ); ?>"
+				title="<?php esc_attr_e( 'Ignore suggestion', 'jot' ); ?>"
 			>×</button>
 			<div class="jot-widget__card-title">
 				<?php if ( ! empty( $badge_list ) ) : ?>


### PR DESCRIPTION
## Summary
- Adds a `title="Ignore suggestion"` attribute to the suggestion-card dismiss button so hovering surfaces the action (matching the Habit Creator widget's pattern).
- Complements the existing per-card `aria-label` with a quick generic hint for sighted mouse users.

Closes #26

## Test plan
- [ ] Load the Jot dashboard widget with at least one suggestion card
- [ ] Hover the × button and confirm "Ignore suggestion" appears
- [ ] Click × and confirm the card is still dismissed correctly