### PR TITLE
Add "Enhance with AI" toggle to the dashboard widget

### DIFF
--- a/assets/jot-widget.css
+++ b/assets/jot-widget.css
@@ -3,6 +3,133 @@
  * Inherits core .postbox chrome; only styles internal structure.
  */
 
+/*
+ * "Enhance with AI" toggle — visual replica of @wordpress/components
+ * ToggleControl. Same markup pattern as the Habit Creator and Draft
+ * Sweeper widgets so the three feel like one feature across plugins.
+ */
+.jot-widget__ai-toggle {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 4px 8px;
+	margin: 0 0 12px;
+	padding: 0 0 10px;
+	border-bottom: 1px solid #f0f0f1;
+}
+
+.jot-widget__ai-toggle-form-toggle {
+	position: relative;
+	display: inline-block;
+	width: 36px;
+	height: 18px;
+	padding: 0;
+	border: 0;
+	background: transparent;
+	cursor: pointer;
+	flex: 0 0 auto;
+	border-radius: 9px;
+}
+
+.jot-widget__ai-toggle-form-toggle:focus-visible {
+	outline: 2px solid var( --wp-admin-theme-color, #2271b1 );
+	outline-offset: 2px;
+}
+
+.jot-widget__ai-toggle-form-toggle .components-form-toggle__track {
+	position: absolute;
+	inset: 0;
+	width: 36px;
+	height: 18px;
+	border-radius: 9px;
+	background: #757575;
+	transition: background 0.1s ease;
+}
+
+.jot-widget__ai-toggle-form-toggle.is-checked .components-form-toggle__track {
+	background: var( --wp-admin-theme-color, #2271b1 );
+}
+
+.jot-widget__ai-toggle-form-toggle .components-form-toggle__thumb {
+	position: absolute;
+	top: 3px;
+	left: 3px;
+	width: 12px;
+	height: 12px;
+	border-radius: 50%;
+	background: #fff;
+	box-shadow: 0 1px 1px rgba( 0, 0, 0, 0.15 );
+	transition: transform 0.1s ease, opacity 0.1s ease;
+}
+
+.jot-widget__ai-toggle-form-toggle.is-checked .components-form-toggle__thumb {
+	transform: translateX( 18px );
+}
+
+.jot-widget__ai-toggle-spinner {
+	position: absolute;
+	top: 5px;
+	left: 5px;
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	border: 1.5px solid rgba( 0, 0, 0, 0.2 );
+	border-top-color: var( --wp-admin-theme-color, #2271b1 );
+	opacity: 0;
+	transition: opacity 0.1s ease, transform 0.1s ease;
+}
+
+.jot-widget__ai-toggle-form-toggle.is-checked .jot-widget__ai-toggle-spinner {
+	transform: translateX( 18px );
+	border-color: rgba( 255, 255, 255, 0.5 );
+	border-top-color: #fff;
+}
+
+.jot-widget__ai-toggle-form-toggle.is-saving .jot-widget__ai-toggle-spinner {
+	opacity: 1;
+	animation: jot-ai-spin 0.6s linear infinite;
+}
+
+.jot-widget__ai-toggle-form-toggle.is-saving .components-form-toggle__thumb {
+	opacity: 0;
+}
+
+.jot-widget__ai-toggle-form-toggle.is-saving .components-form-toggle__track {
+	animation: jot-ai-pulse 0.9s ease-in-out infinite;
+}
+
+.jot-widget__ai-toggle-form-toggle.is-checked.is-saving .jot-widget__ai-toggle-spinner {
+	animation-name: jot-ai-spin-checked;
+}
+
+@keyframes jot-ai-spin {
+	to { transform: translateX( 0 ) rotate( 360deg ); }
+}
+
+@keyframes jot-ai-spin-checked {
+	from { transform: translateX( 18px ) rotate( 0deg ); }
+	to   { transform: translateX( 18px ) rotate( 360deg ); }
+}
+
+@keyframes jot-ai-pulse {
+	0%, 100% { opacity: 1; }
+	50%      { opacity: 0.55; }
+}
+
+.jot-widget__ai-toggle-label {
+	font-size: 13px;
+	color: #1d2327;
+	cursor: pointer;
+	user-select: none;
+}
+
+.jot-widget__ai-toggle-caption {
+	flex: 1 0 100%;
+	margin-left: 44px;
+	font-size: 12px;
+	color: #757575;
+}
+
 .jot-widget__section + .jot-widget__section {
 	margin-top: 16px;
 	padding-top: 12px;

--- a/assets/jot-widget.js
+++ b/assets/jot-widget.js
@@ -43,6 +43,16 @@
 		const t = event.target;
 		if ( ! ( t instanceof HTMLElement ) ) { return; }
 
+		const toggleBtn = t.closest( '.jot-widget__ai-toggle-form-toggle' )
+			|| ( t.classList.contains( 'jot-widget__ai-toggle-label' )
+				? t.parentElement.querySelector( '.jot-widget__ai-toggle-form-toggle' )
+				: null );
+		if ( toggleBtn ) {
+			event.preventDefault();
+			handleAiToggle( toggleBtn );
+			return;
+		}
+
 		if ( t.classList.contains( 'jot-widget__quick-draft' ) ) {
 			event.preventDefault();
 			handleQuickDraft( t, '' );
@@ -56,6 +66,51 @@
 			event.preventDefault();
 			handleRefresh( t );
 		}
+	}
+
+	function handleAiToggle( btn ) {
+		const next     = btn.getAttribute( 'aria-checked' ) !== 'true';
+		const wrap     = btn.closest( '.jot-widget__ai-toggle' );
+		const caption  = wrap ? wrap.querySelector( '.jot-widget__ai-toggle-caption' ) : null;
+
+		// Optimistic flip.
+		btn.classList.toggle( 'is-checked', next );
+		btn.setAttribute( 'aria-checked', next ? 'true' : 'false' );
+		btn.classList.add( 'is-saving' );
+		if ( caption ) {
+			caption.textContent = next
+				? caption.dataset.on
+				: caption.dataset.off;
+		}
+
+		const revert = function () {
+			btn.classList.remove( 'is-saving' );
+			btn.classList.toggle( 'is-checked', ! next );
+			btn.setAttribute( 'aria-checked', next ? 'false' : 'true' );
+			if ( caption ) {
+				caption.textContent = next
+					? caption.dataset.off
+					: caption.dataset.on;
+			}
+		};
+
+		request( 'POST', 'ai-toggle', { enabled: next } ).then( function ( res ) {
+			if ( res.status !== 200 || ! res.data || ! res.data.ok ) {
+				revert();
+				return;
+			}
+			// Re-render so suggestion-card actions reflect the new mode
+			// (tier buttons when AI is on; Quick draft when off).
+			return request( 'GET', 'render' ).then( function ( renderRes ) {
+				if ( renderRes.status === 200 && renderRes.data && renderRes.data.html ) {
+					replaceWidget( renderRes.data.html );
+				} else {
+					btn.classList.remove( 'is-saving' );
+				}
+			} );
+		} ).catch( function () {
+			revert();
+		} );
 	}
 
 	function cardError( card, message ) {

--- a/includes/ai/class-jot-ai.php
+++ b/includes/ai/class-jot-ai.php
@@ -15,13 +15,14 @@ defined( 'ABSPATH' ) || exit;
 
 class Jot_Ai {
 
-	public static function is_available(): bool {
-		// jot_ai_is_available() (in jot.php) checks the Connectors API. Here we
-		// also require the wp-ai-client entry point to exist.
+	public static function is_available( ?int $user_id = null ): bool {
+		// Connectors API + wp-ai-client entry point + the user's per-user
+		// toggle (defaults to on). Pass an explicit user_id from cron / REST
+		// contexts where get_current_user_id() may be 0.
 		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
 			return false;
 		}
-		return jot_ai_is_available();
+		return jot_ai_provider_registered() && jot_ai_user_enabled( $user_id );
 	}
 
 	/**

--- a/includes/cron/class-jot-cron.php
+++ b/includes/cron/class-jot-cron.php
@@ -80,7 +80,7 @@ class Jot_Cron {
 
 		update_user_meta( $user_id, self::USER_DIGESTS_META, $digests );
 
-		if ( class_exists( 'Jot_Ai' ) && Jot_Ai::is_available() && ! empty( $digests ) ) {
+		if ( class_exists( 'Jot_Ai' ) && Jot_Ai::is_available( $user_id ) && ! empty( $digests ) ) {
 			$cards = Jot_Ai::generate_cards(
 				$digests,
 				self::recent_post_titles( $user_id )

--- a/includes/rest/class-jot-rest-controller.php
+++ b/includes/rest/class-jot-rest-controller.php
@@ -72,6 +72,22 @@ class Jot_Rest_Controller {
 
 		register_rest_route(
 			self::NAMESPACE,
+			'/ai-toggle',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( __CLASS__, 'ai_toggle' ),
+				'permission_callback' => array( __CLASS__, 'can_use' ),
+				'args'                => array(
+					'enabled' => array(
+						'required' => true,
+						'type'     => 'boolean',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
 			'/render',
 			array(
 				'methods'             => 'GET',
@@ -203,6 +219,13 @@ class Jot_Rest_Controller {
 			),
 			201
 		);
+	}
+
+	public static function ai_toggle( WP_REST_Request $request ): WP_REST_Response {
+		$enabled = (bool) $request->get_param( 'enabled' );
+		$user_id = get_current_user_id();
+		update_user_meta( $user_id, JOT_USER_AI_ENABLED_META, $enabled ? '1' : '0' );
+		return new WP_REST_Response( array( 'ok' => true, 'enabled' => $enabled ), 200 );
 	}
 
 	public static function dismiss( WP_REST_Request $request ): WP_REST_Response {

--- a/includes/widget/class-jot-dashboard-widget.php
+++ b/includes/widget/class-jot-dashboard-widget.php
@@ -257,13 +257,13 @@ class Jot_Dashboard_Widget {
 			><?php esc_html_e( 'Enhance with AI', 'jot' ); ?></label>
 			<span
 				class="jot-widget__ai-toggle-caption"
-				data-on="<?php esc_attr_e( 'Generations use your connected AI.', 'jot' ); ?>"
-				data-off="<?php esc_attr_e( 'AI is off — prompt-only mode.', 'jot' ); ?>"
+				data-on="<?php esc_attr_e( 'AI labels your activity and writes Spark and Outline drafts.', 'jot' ); ?>"
+				data-off="<?php esc_attr_e( 'Raw activity only — Quick draft uses the digest as-is.', 'jot' ); ?>"
 			><?php
 				echo esc_html(
 					$on
-						? __( 'Generations use your connected AI.', 'jot' )
-						: __( 'AI is off — prompt-only mode.', 'jot' )
+						? __( 'AI labels your activity and writes Spark and Outline drafts.', 'jot' )
+						: __( 'Raw activity only — Quick draft uses the digest as-is.', 'jot' )
 				);
 			?></span>
 		</div>

--- a/includes/widget/class-jot-dashboard-widget.php
+++ b/includes/widget/class-jot-dashboard-widget.php
@@ -258,12 +258,12 @@ class Jot_Dashboard_Widget {
 			<span
 				class="jot-widget__ai-toggle-caption"
 				data-on="<?php esc_attr_e( 'AI labels your activity and writes Spark and Outline drafts.', 'jot' ); ?>"
-				data-off="<?php esc_attr_e( 'Raw activity only — Quick draft uses the digest as-is.', 'jot' ); ?>"
+				data-off="<?php esc_attr_e( 'Your activity stays as it is — Quick draft turns any card into a starter post.', 'jot' ); ?>"
 			><?php
 				echo esc_html(
 					$on
 						? __( 'AI labels your activity and writes Spark and Outline drafts.', 'jot' )
-						: __( 'Raw activity only — Quick draft uses the digest as-is.', 'jot' )
+						: __( 'Your activity stays as it is — Quick draft turns any card into a starter post.', 'jot' )
 				);
 			?></span>
 		</div>

--- a/includes/widget/class-jot-dashboard-widget.php
+++ b/includes/widget/class-jot-dashboard-widget.php
@@ -53,6 +53,8 @@ class Jot_Dashboard_Widget {
 		>
 			<h3 id="jot-widget-heading" class="screen-reader-text"><?php esc_html_e( 'Jot suggestions', 'jot' ); ?></h3>
 
+			<?php $this->render_ai_toggle( $user_id ); ?>
+
 			<section class="jot-widget__section jot-widget__suggestions" aria-live="polite">
 				<h4><?php esc_html_e( 'Suggestions', 'jot' ); ?></h4>
 
@@ -214,6 +216,57 @@ class Jot_Dashboard_Widget {
 			</div>
 			<p class="jot-widget__card-error" role="alert" hidden></p>
 		</li>
+		<?php
+	}
+
+	/**
+	 * "Enhance with AI" toggle — only rendered when an `ai_provider`
+	 * connector is registered via the WP 7.0 Connectors API. Same markup
+	 * and class semantics as the Habit Creator and Draft Sweeper widgets
+	 * so the three feel like one feature across plugins. The
+	 * `?jot_force_toggle=1` query flag is a design-review escape hatch.
+	 */
+	private function render_ai_toggle( int $user_id ): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended — read-only UI flag.
+		$force = ! empty( $_GET['jot_force_toggle'] );
+		if ( ! jot_ai_provider_registered() && ! $force ) {
+			return;
+		}
+
+		$on = jot_ai_user_enabled( $user_id );
+		$classes = array( 'components-form-toggle', 'jot-widget__ai-toggle-form-toggle' );
+		if ( $on ) {
+			$classes[] = 'is-checked';
+		}
+		?>
+		<div class="jot-widget__ai-toggle">
+			<button
+				type="button"
+				class="<?php echo esc_attr( implode( ' ', $classes ) ); ?>"
+				role="switch"
+				aria-checked="<?php echo $on ? 'true' : 'false'; ?>"
+				aria-labelledby="jot-widget__ai-toggle-label"
+			>
+				<span class="components-form-toggle__track" aria-hidden="true"></span>
+				<span class="components-form-toggle__thumb" aria-hidden="true"></span>
+				<span class="jot-widget__ai-toggle-spinner" aria-hidden="true"></span>
+			</button>
+			<label
+				id="jot-widget__ai-toggle-label"
+				class="jot-widget__ai-toggle-label"
+			><?php esc_html_e( 'Enhance with AI', 'jot' ); ?></label>
+			<span
+				class="jot-widget__ai-toggle-caption"
+				data-on="<?php esc_attr_e( 'Generations use your connected AI.', 'jot' ); ?>"
+				data-off="<?php esc_attr_e( 'AI is off — prompt-only mode.', 'jot' ); ?>"
+			><?php
+				echo esc_html(
+					$on
+						? __( 'Generations use your connected AI.', 'jot' )
+						: __( 'AI is off — prompt-only mode.', 'jot' )
+				);
+			?></span>
+		</div>
 		<?php
 	}
 

--- a/jot.php
+++ b/jot.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Jot
  * Plugin URI:        https://github.com/annemccarthy/jot
  * Description:       A dashboard widget that surfaces post-idea suggestions drawn from your activity on connected services. Works without AI; becomes more useful with an AI provider connected.
- * Version:           0.1.0
+ * Version:           0.2.0
  * Requires at least: 7.0
  * Requires PHP:      8.1
  * Author:            Anne McCarthy
@@ -19,7 +19,7 @@ declare( strict_types=1 );
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'JOT_VERSION', '0.1.0' );
+define( 'JOT_VERSION', '0.2.0' );
 define( 'JOT_PLUGIN_FILE', __FILE__ );
 define( 'JOT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'JOT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
@@ -190,7 +190,7 @@ function jot_get_connected_services( ?int $user_id = null ): array {
 /**
  * Is an AI provider configured via the WP 7.0 Connectors API?
  */
-function jot_ai_is_available(): bool {
+function jot_ai_provider_registered(): bool {
 	if ( ! function_exists( 'wp_get_connectors' ) ) {
 		return false;
 	}
@@ -200,6 +200,34 @@ function jot_ai_is_available(): bool {
 		}
 	}
 	return false;
+}
+
+/**
+ * Per-user toggle for AI enhancement. Defaults to on. Surfaced to the user
+ * as the "Enhance with AI" switch in the dashboard widget header — only
+ * visible when an `ai_provider` connector is registered.
+ */
+const JOT_USER_AI_ENABLED_META = 'jot_ai_enabled';
+
+function jot_ai_user_enabled( ?int $user_id = null ): bool {
+	$user_id = $user_id ?? get_current_user_id();
+	if ( $user_id === 0 ) {
+		return true;
+	}
+	$stored = get_user_meta( $user_id, JOT_USER_AI_ENABLED_META, true );
+	// Default to enabled when meta is unset or empty.
+	if ( $stored === '' || $stored === false ) {
+		return true;
+	}
+	return (string) $stored === '1';
+}
+
+/**
+ * Connector present AND user has AI enabled. The previous helper name is
+ * kept as a thin alias so existing callsites keep working.
+ */
+function jot_ai_is_available(): bool {
+	return jot_ai_provider_registered() && jot_ai_user_enabled();
 }
 
 /**

--- a/playground/blueprint.json
+++ b/playground/blueprint.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+  "preferredVersions": { "php": "8.3", "wp": "beta" },
+  "landingPage": "/wp-admin/index.php?jot_force_toggle=1",
+  "login": true,
+  "steps": [
+    {
+      "step": "installPlugin",
+      "pluginData": {
+        "resource": "url",
+        "url": "https://github-proxy.com/proxy/?repo=annezazu/jot&branch=add/enhance-with-ai-toggle"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Carries the unified AI-toggle pattern from [habit-creator#5](https://github.com/annezazu/habit-creator/pull/5) and [draft-sweeper#13](https://github.com/annezazu/draft-sweeper/pull/13) into Jot. Same markup, save animation, and caption pattern across all three so the toggle feels like one feature regardless of which widget the user is in.

- ToggleControl-style switch in the widget header labeled **Enhance with AI**.
- Only rendered when an `ai_provider` connector is registered via the WP 7.0 Connectors API.
- Caption swaps between **"Generations use your connected AI."** (on) and **"AI is off — prompt-only mode."** (off).
- Saving state during the round-trip (thumb fades, spinner appears, track pulses). Then the widget re-renders via the existing `/jot/v1/render` endpoint, so suggestion cards immediately reflect the new mode — tier buttons (Quick spark / Outline) when AI is on; single **Quick draft** button when off.
- `?jot_force_toggle=1` design-review escape hatch.

## Plumbing

- `jot_ai_is_available()` → split into `jot_ai_provider_registered()` (Connectors-API check, system-level) + new `jot_ai_user_enabled( $user_id )` (per-user, defaults to on).
- `Jot_Ai::is_available()` now accepts an explicit `?int $user_id` so cron can check the right user's preference instead of the (zero) running-user id. REST callers still use the default which resolves to the current user.
- New `POST /jot/v1/ai-toggle` endpoint persists the user_meta and returns `{ ok, enabled }`. JS chases it with `GET /jot/v1/render` to swap the widget HTML.

## Test plan

- [ ] Open Playground blueprint → toggle visible in widget header
- [ ] Click toggle → save spinner shows, then widget re-renders
- [ ] With cards present, toggle ON → tier buttons (Quick spark / Outline)
- [ ] With cards present, toggle OFF → single Quick draft button + "Connect an AI provider…" muted line
- [ ] Reload → state persists per-user
- [ ] On a real install with no AI connector → toggle hidden
- [ ] Cron run for a user with toggle off → does not call AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)