### PR TITLE
Strip empty-state chrome from the Jot widget

### DIFF
--- a/assets/jot-widget.css
+++ b/assets/jot-widget.css
@@ -145,7 +145,7 @@
 
 .jot-widget__empty {
 	text-align: center;
-	padding: 12px 8px;
+	padding: 20px 12px 24px;
 	color: #50575e;
 }
 

--- a/includes/widget/class-jot-dashboard-widget.php
+++ b/includes/widget/class-jot-dashboard-widget.php
@@ -38,12 +38,36 @@ class Jot_Dashboard_Widget {
 		$user_id         = get_current_user_id();
 		$connections     = jot_get_connected_services( $user_id );
 		$connections_url = admin_url( 'admin.php?page=jot-connections' );
-		$last_refresh    = (int) get_user_meta( $user_id, Jot_Cron::USER_LAST_REFRESH, true );
-		$ai_available    = class_exists( 'Jot_Ai' ) && Jot_Ai::is_available();
-		$ai_error        = (string) get_user_meta( $user_id, Jot_Cron::USER_AI_ERROR_META, true );
 
-		$cards   = $this->build_card_list( $user_id );
-		$drafts  = $this->get_jot_drafts();
+		// No connections: render only the connect CTA. Drafts list and refresh
+		// footer are suppressed so the user has a single, unambiguous next step.
+		if ( empty( $connections ) ) {
+			?>
+			<div class="jot-widget jot-widget--empty"
+				aria-labelledby="jot-widget-heading"
+				data-rest-root="<?php echo esc_attr( esc_url_raw( rest_url( Jot_Rest_Controller::NAMESPACE . '/' ) ) ); ?>"
+				data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>"
+			>
+				<h3 id="jot-widget-heading" class="screen-reader-text"><?php esc_html_e( 'Jot suggestions', 'jot' ); ?></h3>
+				<div class="jot-widget__empty">
+					<p><?php esc_html_e( 'Connect a service and Jot will suggest post ideas from your activity.', 'jot' ); ?></p>
+					<p>
+						<a class="button button-primary" href="<?php echo esc_url( $connections_url ); ?>">
+							<?php esc_html_e( 'Connect a service', 'jot' ); ?>
+						</a>
+					</p>
+				</div>
+			</div>
+			<?php
+			return;
+		}
+
+		$last_refresh = (int) get_user_meta( $user_id, Jot_Cron::USER_LAST_REFRESH, true );
+		$ai_available = class_exists( 'Jot_Ai' ) && Jot_Ai::is_available();
+		$ai_error     = (string) get_user_meta( $user_id, Jot_Cron::USER_AI_ERROR_META, true );
+
+		$cards  = $this->build_card_list( $user_id );
+		$drafts = $this->get_jot_drafts();
 
 		?>
 		<div class="jot-widget"
@@ -122,20 +146,6 @@ class Jot_Dashboard_Widget {
 	 * @param array<int, array<string, mixed>>                      $cards
 	 */
 	private function render_suggestions( int $user_id, array $connections, array $cards, bool $ai_available, string $ai_error, string $connections_url ): void {
-		if ( empty( $connections ) ) {
-			?>
-			<div class="jot-widget__empty">
-				<p><?php esc_html_e( "Connect a service and Jot will suggest post ideas from your activity.", 'jot' ); ?></p>
-				<p>
-					<a class="button button-primary" href="<?php echo esc_url( $connections_url ); ?>">
-						<?php esc_html_e( 'Connect a service', 'jot' ); ?>
-					</a>
-				</p>
-			</div>
-			<?php
-			return;
-		}
-
 		if ( empty( $cards ) ) {
 			?>
 			<div class="jot-widget__empty">

--- a/jot.php
+++ b/jot.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Jot
  * Plugin URI:        https://github.com/annemccarthy/jot
  * Description:       A dashboard widget that surfaces post-idea suggestions drawn from your activity on connected services. Works without AI; becomes more useful with an AI provider connected.
- * Version:           0.2.0
+ * Version:           0.2.1
  * Requires at least: 7.0
  * Requires PHP:      8.1
  * Author:            Anne McCarthy
@@ -19,7 +19,7 @@ declare( strict_types=1 );
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'JOT_VERSION', '0.2.0' );
+define( 'JOT_VERSION', '0.2.1' );
 define( 'JOT_PLUGIN_FILE', __FILE__ );
 define( 'JOT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'JOT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
Strip every element from the Jot widget's no-connections state except the connect CTA. A user with no services connected has nothing to act on except connecting, so the "Suggestions" heading, the empty "Your drafts from Jot" section, and the "Not yet refreshed." footer status are all dead chrome that fights the actual CTA for attention.

Before: nine visible elements competing for attention, only one of which is actionable.
After: two — explanatory copy + a single primary button.

Implementation:
- `render()` short-circuits when `$connections` is empty and emits only the `.jot-widget__empty` markup. No section wrapper, no h4, no drafts section, no footer.
- The unreachable empty-connections branch in `render_suggestions()` is removed.
- `.jot-widget__empty` gets a small padding bump (12px → 24px bottom) so it has presence as the only content in the widget.

## Test plan
- [ ] Visit the dashboard as a user with no Jot connections — widget shows only the copy and button
- [ ] Click "Connect a service" — routes to the connections admin page
- [ ] Connect a service — widget switches to the full layout (Suggestions section + drafts + footer)
- [ ] Disconnect all services — widget returns to the minimal CTA state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
