### PR TITLE
Widget polish: redesigned suggestions, drafts panel, draft-promotion flow, AI gate fix

### DIFF
--- a/assets/jot-widget.css
+++ b/assets/jot-widget.css
@@ -3,18 +3,48 @@
  * Inherits core .postbox chrome; only styles internal structure.
  */
 
+/* Zero the 11px top/bottom margin core puts on .postbox .inside so our
+   own section padding controls all the breathing room. Scoped to the Jot
+   postbox so other widgets aren't affected. */
+#jot_dashboard_widget .inside {
+	margin: 0;
+}
+
+/* Escape the .postbox .inside 12px padding on the sides and bottom so the
+   widget owns the full postbox interior. With this in place, every inner
+   block (sections, drafts panel, footer) can share the same 22px horizontal
+   padding and end up visually aligned. Same idiom Draft Sweeper uses. */
+.jot-widget {
+	margin: 0 -12px -12px;
+}
+
+.jot-widget__section {
+	padding: 24px 22px;
+}
+
+/* Drafts section: gray panel that spans the widget's full width, with
+   hairlines top and bottom, matching the Ideas Inbox and Draft Sweeper
+   widgets. */
+.jot-widget__section.jot-widget__drafts {
+	background: var( --wpds-color-bg-surface-neutral-weak, #f6f7f7 );
+	border-top: 1px solid var( --wpds-color-stroke-surface-neutral-weak, #dcdcde );
+	border-bottom: 1px solid var( --wpds-color-stroke-surface-neutral-weak, #dcdcde );
+}
+
 /*
  * "Enhance with AI" toggle — visual replica of @wordpress/components
  * ToggleControl. Same markup pattern as the Habit Creator and Draft
  * Sweeper widgets so the three feel like one feature across plugins.
+ * Picks up the 22px gutter the rest of the widget uses so the toggle
+ * row aligns with section content.
  */
 .jot-widget__ai-toggle {
 	display: flex;
 	align-items: center;
 	flex-wrap: wrap;
 	gap: 4px 8px;
-	margin: 0 0 12px;
-	padding: 0 0 10px;
+	margin: 0;
+	padding: 12px 22px;
 	border-bottom: 1px solid #f0f0f1;
 }
 
@@ -130,13 +160,7 @@
 	color: #757575;
 }
 
-.jot-widget__section + .jot-widget__section {
-	margin-top: 16px;
-	padding-top: 12px;
-	border-top: 1px solid #f0f0f1;
-}
-
-.jot-widget__section h4 {
+.jot-widget__section h3 {
 	margin: 0 0 8px;
 	font-size: 14px;
 	font-weight: 600;
@@ -202,12 +226,15 @@
 }
 
 .jot-widget__card {
-	padding: 10px 12px;
-	border: 1px solid #f0f0f1;
-	border-radius: 4px;
+	padding: 10px 0;
 	margin-bottom: 8px;
 	position: relative;
 	transition: opacity 150ms ease, transform 150ms ease;
+}
+
+.jot-widget__card:last-child {
+	margin-bottom: 0;
+	padding-bottom: 0;
 }
 
 .jot-widget__card--dismissing {
@@ -217,15 +244,17 @@
 }
 
 .jot-widget__card-title {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: 12px;
 	margin-bottom: 6px;
-	padding-right: 22px; /* room for the dismiss × */
 }
 
 .jot-widget__card-badges {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 4px;
-	margin-bottom: 6px;
 }
 
 .jot-widget__card-badge {
@@ -239,7 +268,6 @@
 }
 
 .jot-widget__card-headline {
-	display: block;
 	line-height: 1.3;
 }
 
@@ -252,8 +280,28 @@
 
 .jot-widget__card-actions {
 	display: flex;
-	gap: 6px;
+	gap: 12px;
 	flex-wrap: wrap;
+	align-items: center;
+}
+
+.jot-widget__dismiss {
+	background: none;
+	border: 0;
+	padding: 0;
+	margin: 0;
+	box-shadow: none;
+	cursor: pointer;
+	font: inherit;
+	color: var( --wp-admin-theme-color, #2271b1 );
+	text-decoration: none;
+}
+
+.jot-widget__dismiss:hover,
+.jot-widget__dismiss:focus {
+	background: transparent;
+	color: var( --wp-admin-theme-color, #2271b1 );
+	text-decoration: underline;
 }
 
 .jot-widget__card-error {
@@ -263,32 +311,6 @@
 	background: #fbeaea;
 	border-radius: 3px;
 	font-size: 12px;
-}
-
-.jot-widget__card-success {
-	margin: 0;
-	color: #1d4d2e;
-	font-size: 13px;
-}
-
-.jot-widget__dismiss {
-	position: absolute;
-	top: 4px;
-	right: 6px;
-	background: transparent;
-	border: 0;
-	font-size: 18px;
-	line-height: 1;
-	padding: 2px 6px;
-	color: #787c82;
-	cursor: pointer;
-	border-radius: 3px;
-}
-
-.jot-widget__dismiss:hover,
-.jot-widget__dismiss:focus {
-	color: #1d2327;
-	background: #f0f0f1;
 }
 
 .jot-widget__drafts-list {
@@ -303,11 +325,25 @@
 	align-items: baseline;
 	gap: 8px;
 	padding: 4px 0;
-	border-bottom: 1px solid #f6f7f7;
 }
 
 .jot-widget__draft:last-child {
-	border-bottom: 0;
+	padding-bottom: 0;
+}
+
+/* Brief tinted flash on rows that were just promoted from a suggestion card,
+   so the user can see where the new draft landed in the list. */
+.jot-widget__draft--new {
+	animation: jot-draft-flash 1800ms ease-out;
+}
+
+@keyframes jot-draft-flash {
+	0%, 30% {
+		background-color: color-mix( in srgb, var( --wp-admin-theme-color, #2271b1 ) 18%, transparent );
+	}
+	100% {
+		background-color: transparent;
+	}
 }
 
 .jot-widget__draft-title {
@@ -341,12 +377,10 @@
 }
 
 .jot-widget__footer {
-	margin-top: 16px;
-	padding-top: 8px;
-	border-top: 1px solid #f0f0f1;
+	padding: 14px 22px;
 	font-size: 12px;
 	display: flex;
-	justify-content: space-between;
+	gap: 12px;
 	align-items: center;
 }
 

--- a/assets/jot-widget.js
+++ b/assets/jot-widget.js
@@ -142,15 +142,12 @@
 
 		request( 'POST', 'draft', body ).then( function ( res ) {
 			if ( res.status === 201 && res.data && res.data.ok ) {
-				const editUrl = res.data.edit_url || '#';
-				card.innerHTML =
-					'<p class="jot-widget__card-success">' +
-					escapeHtml( __( 'Draft created' ) ) + ' — ' +
-					'<a href="' + escapeHtml( editUrl ) + '">' + escapeHtml( __( 'Edit' ) ) + '</a>' +
-					'</p>';
-				// Move focus so the screen reader announces the new link.
-				const link = card.querySelector( 'a' );
-				if ( link ) { link.focus(); }
+				promoteCardToDraft(
+					card,
+					res.data.title || '',
+					res.data.edit_url || '#',
+					res.data.tier || ''
+				);
 			} else {
 				siblings.forEach( function ( b ) { b.disabled = false; } );
 				button.textContent = originalLabel;
@@ -163,6 +160,88 @@
 		} );
 	}
 
+	// Slide the source card out and insert a freshly-created draft into the
+	// drafts list below, with a brief background flash so it's obvious where
+	// the new draft landed. The drafts section is an aria-live region, so
+	// screen readers get the announcement without us moving focus into the
+	// new row (which would leave a focus ring during the fade).
+	function promoteCardToDraft( card, title, editUrl, tier ) {
+		const row = buildDraftRow( title, editUrl, tier );
+		insertDraftRow( row );
+
+		card.classList.add( 'jot-widget__card--dismissing' );
+		setTimeout( function () { card.remove(); maybeShowAllCaughtUp(); }, 180 );
+	}
+
+	// When the user has acted on every visible suggestion (drafted or ignored),
+	// swap the now-empty list for a calm "all caught up" state. Only fires
+	// after a user action — the cron-empty case keeps its own server-rendered
+	// "Nothing new in your activity yet" copy.
+	function maybeShowAllCaughtUp() {
+		const list = document.querySelector( '.jot-widget__digests' );
+		if ( ! list || list.children.length > 0 ) { return; }
+
+		const empty = document.createElement( 'div' );
+		empty.className = 'jot-widget__empty';
+		const p = document.createElement( 'p' );
+		p.textContent = __( 'All caught up! Work on your drafts, refresh the connection, or come back tomorrow.' );
+		empty.appendChild( p );
+		list.replaceWith( empty );
+	}
+
+	function buildDraftRow( title, editUrl, tier ) {
+		const li = document.createElement( 'li' );
+		li.className = 'jot-widget__draft jot-widget__draft--new';
+
+		const titleLink = document.createElement( 'a' );
+		titleLink.className = 'jot-widget__draft-title';
+		titleLink.href = editUrl;
+		titleLink.textContent = title || __( '(no title)' );
+		li.appendChild( titleLink );
+
+		const meta = document.createElement( 'span' );
+		meta.className = 'jot-widget__draft-meta';
+
+		if ( tier && tier !== 'quick_draft' ) {
+			const pill = document.createElement( 'span' );
+			pill.className = 'jot-widget__tier-pill';
+			pill.textContent = tierLabel( tier );
+			meta.appendChild( pill );
+		}
+
+		const when = document.createElement( 'span' );
+		when.className = 'jot-widget__muted';
+		when.textContent = __( 'Just now' );
+		meta.appendChild( when );
+
+		li.appendChild( meta );
+		return li;
+	}
+
+	function insertDraftRow( row ) {
+		const section = document.querySelector( '.jot-widget__drafts' );
+		if ( ! section ) { return false; }
+
+		let list = section.querySelector( '.jot-widget__drafts-list' );
+		if ( ! list ) {
+			// The drafts section was rendered with the empty hint. Swap the hint
+			// out for a real list so we have somewhere to add to.
+			const hint = section.querySelector( '.jot-widget__muted' );
+			if ( hint ) { hint.remove(); }
+			list = document.createElement( 'ul' );
+			list.className = 'jot-widget__drafts-list';
+			section.appendChild( list );
+		}
+		list.insertBefore( row, list.firstChild );
+		return true;
+	}
+
+	function tierLabel( tier ) {
+		if ( tier === 'spark' )   { return __( 'Spark' ); }
+		if ( tier === 'outline' ) { return __( 'Outline' ); }
+		return tier;
+	}
+
 	function handleDismiss( button ) {
 		const card = button.closest( '.jot-widget__card' );
 		if ( ! card ) { return; }
@@ -172,7 +251,7 @@
 		card.classList.add( 'jot-widget__card--dismissing' );
 		request( 'POST', 'dismiss', { angle_key: angleKey } ).then( function ( res ) {
 			if ( res.status === 200 && res.data && res.data.ok ) {
-				setTimeout( function () { card.remove(); }, 180 );
+				setTimeout( function () { card.remove(); maybeShowAllCaughtUp(); }, 180 );
 			} else {
 				card.classList.remove( 'jot-widget__card--dismissing' );
 			}

--- a/includes/ai/class-jot-ai.php
+++ b/includes/ai/class-jot-ai.php
@@ -16,12 +16,9 @@ defined( 'ABSPATH' ) || exit;
 class Jot_Ai {
 
 	public static function is_available( ?int $user_id = null ): bool {
-		// Connectors API + wp-ai-client entry point + the user's per-user
-		// toggle (defaults to on). Pass an explicit user_id from cron / REST
-		// contexts where get_current_user_id() may be 0.
-		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
-			return false;
-		}
+		// Composite: a usable text-gen model in the registry AND the user's
+		// per-user toggle (defaults to on). Pass an explicit user_id from
+		// cron / REST contexts where get_current_user_id() may be 0.
 		return jot_ai_provider_registered() && jot_ai_user_enabled( $user_id );
 	}
 

--- a/includes/rest/class-jot-rest-controller.php
+++ b/includes/rest/class-jot-rest-controller.php
@@ -215,6 +215,7 @@ class Jot_Rest_Controller {
 				'ok'       => true,
 				'post_id'  => (int) $post_id,
 				'tier'     => $used_tier,
+				'title'    => $title,
 				'edit_url' => get_edit_post_link( (int) $post_id, 'raw' ),
 			),
 			201

--- a/includes/widget/class-jot-dashboard-widget.php
+++ b/includes/widget/class-jot-dashboard-widget.php
@@ -44,11 +44,9 @@ class Jot_Dashboard_Widget {
 		if ( empty( $connections ) ) {
 			?>
 			<div class="jot-widget jot-widget--empty"
-				aria-labelledby="jot-widget-heading"
 				data-rest-root="<?php echo esc_attr( esc_url_raw( rest_url( Jot_Rest_Controller::NAMESPACE . '/' ) ) ); ?>"
 				data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>"
 			>
-				<h3 id="jot-widget-heading" class="screen-reader-text"><?php esc_html_e( 'Jot suggestions', 'jot' ); ?></h3>
 				<div class="jot-widget__empty">
 					<p><?php esc_html_e( 'Connect a service and Jot will suggest post ideas from your activity.', 'jot' ); ?></p>
 					<p>
@@ -71,22 +69,19 @@ class Jot_Dashboard_Widget {
 
 		?>
 		<div class="jot-widget"
-			aria-labelledby="jot-widget-heading"
 			data-rest-root="<?php echo esc_attr( esc_url_raw( rest_url( Jot_Rest_Controller::NAMESPACE . '/' ) ) ); ?>"
 			data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>"
 		>
-			<h3 id="jot-widget-heading" class="screen-reader-text"><?php esc_html_e( 'Jot suggestions', 'jot' ); ?></h3>
-
 			<?php $this->render_ai_toggle( $user_id ); ?>
 
 			<section class="jot-widget__section jot-widget__suggestions" aria-live="polite">
-				<h4><?php esc_html_e( 'Suggestions', 'jot' ); ?></h4>
+				<h3><?php esc_html_e( 'Post suggestions from your connected accounts', 'jot' ); ?></h3>
 
 				<?php $this->render_suggestions( $user_id, $connections, $cards, $ai_available, $ai_error, $connections_url ); ?>
 			</section>
 
-			<section class="jot-widget__section jot-widget__drafts">
-				<h4><?php esc_html_e( 'Your drafts from Jot', 'jot' ); ?></h4>
+			<section class="jot-widget__section jot-widget__drafts" aria-live="polite">
+				<h3><?php esc_html_e( 'Your drafts from Jot', 'jot' ); ?></h3>
 				<?php if ( empty( $drafts ) ) : ?>
 					<p class="jot-widget__muted"><?php esc_html_e( 'Jot drafts appear here once you create them.', 'jot' ); ?></p>
 				<?php else : ?>
@@ -117,6 +112,9 @@ class Jot_Dashboard_Widget {
 			</section>
 
 			<footer class="jot-widget__footer">
+				<button type="button" class="button button-small jot-widget__refresh">
+					<?php esc_html_e( 'Refresh', 'jot' ); ?>
+				</button>
 				<span class="jot-widget__muted jot-widget__refreshed"
 					<?php if ( $last_refresh > 0 ) : ?>
 						title="<?php echo esc_attr( wp_date( 'c', $last_refresh ) ); ?>"
@@ -125,17 +123,12 @@ class Jot_Dashboard_Widget {
 					<?php
 					if ( $last_refresh > 0 ) {
 						/* translators: %s: human time diff e.g. "2 hours" */
-						printf( esc_html__( 'Refreshed %s ago', 'jot' ), esc_html( human_time_diff( $last_refresh, time() ) ) );
+						printf( esc_html__( 'Connections refreshed %s ago', 'jot' ), esc_html( human_time_diff( $last_refresh, time() ) ) );
 					} else {
-						esc_html_e( 'Not yet refreshed.', 'jot' );
+						esc_html_e( 'Connections not yet refreshed.', 'jot' );
 					}
 					?>
 				</span>
-				<?php if ( ! empty( $connections ) ) : ?>
-					<button type="button" class="button button-small jot-widget__refresh">
-						<?php esc_html_e( 'Refresh', 'jot' ); ?>
-					</button>
-				<?php endif; ?>
 			</footer>
 		</div>
 		<?php
@@ -192,25 +185,18 @@ class Jot_Dashboard_Widget {
 			$labels = array( (string) $card['label'] );
 		}
 		$badge_list = $this->badges_for( $labels );
-		$badge_aria = $labels ? implode( ', ', $labels ) : '';
 		?>
 		<li class="jot-widget__card" data-angle-key="<?php echo esc_attr( $angle_key ); ?>">
-			<button
-				type="button"
-				class="jot-widget__dismiss"
-				aria-label="<?php echo esc_attr( sprintf( /* translators: %s: card title */ __( 'Dismiss: %s', 'jot' ), $title !== '' ? $title : $badge_aria ) ); ?>"
-				title="<?php esc_attr_e( 'Ignore suggestion', 'jot' ); ?>"
-			>×</button>
 			<div class="jot-widget__card-title">
+				<?php if ( $title !== '' ) : ?>
+					<strong class="jot-widget__card-headline"><?php echo esc_html( $title ); ?></strong>
+				<?php endif; ?>
 				<?php if ( ! empty( $badge_list ) ) : ?>
 					<div class="jot-widget__card-badges">
 						<?php foreach ( $badge_list as $badge ) : ?>
 							<span class="jot-widget__card-badge"><?php echo esc_html( $badge ); ?></span>
 						<?php endforeach; ?>
 					</div>
-				<?php endif; ?>
-				<?php if ( $title !== '' ) : ?>
-					<strong class="jot-widget__card-headline"><?php echo esc_html( $title ); ?></strong>
 				<?php endif; ?>
 			</div>
 			<p class="jot-widget__card-digest"><?php echo esc_html( $body ); ?></p>
@@ -223,6 +209,9 @@ class Jot_Dashboard_Widget {
 						<?php esc_html_e( 'Quick draft', 'jot' ); ?>
 					</button>
 				<?php endif; ?>
+				<button type="button" class="jot-widget__dismiss">
+					<?php esc_html_e( 'Ignore suggestion', 'jot' ); ?>
+				</button>
 			</div>
 			<p class="jot-widget__card-error" role="alert" hidden></p>
 		</li>

--- a/jot.php
+++ b/jot.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Jot
  * Plugin URI:        https://github.com/annemccarthy/jot
  * Description:       A dashboard widget that surfaces post-idea suggestions drawn from your activity on connected services. Works without AI; becomes more useful with an AI provider connected.
- * Version:           0.2.1
+ * Version:           0.2.2
  * Requires at least: 7.0
  * Requires PHP:      8.1
  * Author:            Anne McCarthy
@@ -19,7 +19,7 @@ declare( strict_types=1 );
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'JOT_VERSION', '0.2.1' );
+define( 'JOT_VERSION', '0.2.2' );
 define( 'JOT_PLUGIN_FILE', __FILE__ );
 define( 'JOT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'JOT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
@@ -188,18 +188,26 @@ function jot_get_connected_services( ?int $user_id = null ): array {
 }
 
 /**
- * Is an AI provider configured via the WP 7.0 Connectors API?
+ * Is there an AI provider that can actually generate text right now?
+ *
+ * wp_get_connectors() reports providers that are *registered* — not ones that
+ * have credentials wired up. Probing the wp-ai-client registry directly is the
+ * only check that catches "registered but no API key" and matches the model
+ * lookup that generate_text() will perform at click time. Cached per request
+ * since the widget calls this on every dashboard render and on every REST hit.
  */
 function jot_ai_provider_registered(): bool {
-	if ( ! function_exists( 'wp_get_connectors' ) ) {
-		return false;
+	static $cached = null;
+	if ( $cached !== null ) {
+		return $cached;
 	}
-	foreach ( (array) wp_get_connectors() as $connector ) {
-		if ( ( $connector['type'] ?? '' ) === 'ai_provider' ) {
-			return true;
-		}
+	if ( ! function_exists( 'wp_ai_client_prompt' ) || ! function_exists( 'wp_supports_ai' ) ) {
+		return $cached = false;
 	}
-	return false;
+	if ( ! wp_supports_ai() ) {
+		return $cached = false;
+	}
+	return $cached = wp_ai_client_prompt( 'probe' )->is_supported_for_text_generation();
 }
 
 /**


### PR DESCRIPTION
## Summary
Replaces [#31](https://github.com/annezazu/jot/pull/31), which GitHub auto-closed when its base branch (`redesign/widget-empty-state` from #30) was deleted on merge. Same head branch (`design/widget-suggestions-polish`), retargeted to `main`. The branch was also rebased onto the post-#29 main and the polish commits squashed into one so the integration with the new "Enhance with AI" toggle could be resolved in a single conflict pass.

### Section / heading
- Rename "Suggestions" → "Post suggestions from your connected accounts"
- Promote both section headings (suggestions + drafts) from `<h4>` to `<h3>` so they match Habit Creator / Future Drafts, and drop the now-redundant screen-reader-only `<h3 id="jot-widget-heading">`
- Drop the per-card border; cards sit flush, separated only by margin
- Inline the service badge (Strava / GitHub / etc.) 12px after the title, baseline aligned
- Bump card-actions gap to 12px to match Draft Sweeper and Habit Creator

### Bug fix: "No models found that support text_generation for this prompt."
- `jot_ai_provider_registered()` was returning true whenever any `ai_provider` connector was *registered* — even with no API key configured. That mismatch let the widget advertise Quick spark / Outline buttons that blew up at click time
- Replace the connector-list scan with the wp-ai-client model-registry probe (`wp_ai_client_prompt('probe')->is_supported_for_text_generation()`). Composed with #29's per-user toggle via the existing `jot_ai_is_available()` helper

### Dismiss affordance
- Add an inline "Ignore suggestion" text link in the card actions row (theme-color, hover underline)
- Drop the dismiss × in the top-right corner (added by [#27](https://github.com/annezazu/jot/pull/27)) — the new link covers the same action

### Drafts section
- Style as a full-width gray panel with top + bottom hairlines, matching Ideas Inbox and Draft Sweeper
- Drop the inter-draft hairline — the gray panel does the separation work

### Footer
- Reflow: Refresh button on the left, status text 12px to its right
- Rename status from "Refreshed X ago" → "Connections refreshed X ago"
- Drop the footer's own top border and margin

### Drafted-card animation
- When a card is acted on, it slides out and the new draft is inserted at the top of the drafts list with a brief tinted background flash that fades to transparent
- `/jot/draft` REST endpoint also returns the saved `title` so the JS can populate the row without a second round-trip
- Drafts section gets `aria-live="polite"` so screen readers still get the announcement without moving focus (which left a visible outline during the fade)

### All-caught-up state
- When the user acts on every visible suggestion (drafted or ignored), the now-empty list is replaced inline with "All caught up! Work on your drafts, refresh the connection, or come back tomorrow."
- Only fires from user action — the cron-empty case keeps its own server-rendered copy

### Alignment cleanup
- Move the `.postbox .inside` escape from the drafts section up to `.jot-widget` itself (the Draft Sweeper idiom): once the wrapper escapes the .inside padding, every inner block shares 22px horizontal padding
- Apply Draft Sweeper-style 24px 22px padding to `.jot-widget__section`
- Zero the 11px top/bottom margin core puts on `#jot_dashboard_widget .inside`
- Zero the bottom margin/padding on the last card and last draft
- Bring the new AI toggle from #29 into the same 22px gutter so it aligns with the section content below

## Test plan
- [ ] Without an AI provider configured: each card has a single **Quick draft** button + Ignore link; hint "Connect an AI provider…" shows above the cards; no Spark/Outline anywhere
- [ ] With an AI provider connected: each card has **Quick spark** + **Outline** + Ignore link
- [ ] With AI provider connected but the per-user "Enhance with AI" toggle off: falls back to the no-AI flow (verifies #29 composition still works)
- [ ] Click Quick draft / Spark / Outline: card slides out, new draft appears at top of drafts list with brief flash, no focus ring
- [ ] Click Ignore suggestion: card slides out, no draft created
- [ ] Act on every card: suggestions area swaps in "All caught up!"
- [ ] Drafts panel: gray bg, top + bottom hairlines, full postbox width, content lined up with suggestions and footer
- [ ] Footer: Refresh button on left, "Connections refreshed X ago" 12px to its right

🤖 Generated with [Claude Code](https://claude.com/claude-code)
